### PR TITLE
Use refactored client failure

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/DescribeServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/DescribeServiceHandler.scala
@@ -4,6 +4,7 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisResolved
+import org.broadinstitute.dsde.vault.services.ClientFailure
 import org.broadinstitute.dsde.vault.services.analysis.DescribeServiceHandler.DescribeMessage
 import spray.routing.RequestContext
 
@@ -30,10 +31,11 @@ case class DescribeServiceHandler(requestContext: RequestContext, dmService: Act
       requestContext.complete(analysis)
       context.stop(self)
 
-    case unknown =>
-      log.error("Client failure: " + unknown)
+    case ClientFailure(message: String) =>
+      log.error("Client failure: " + message)
       requestContext.reject()
       context.stop(self)
+
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestServiceHandler.scala
@@ -5,6 +5,7 @@ import akka.event.Logging
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisCreated
 import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.ClientFailure
 import org.broadinstitute.dsde.vault.services.analysis.IngestServiceHandler.IngestMessage
 import spray.routing.RequestContext
 
@@ -34,8 +35,8 @@ case class IngestServiceHandler(requestContext: RequestContext, dmService: Actor
       requestContext.complete(analysis)
       context.stop(self)
 
-    case unknown =>
-      log.error("Client failure: " + unknown)
+    case ClientFailure(message: String) =>
+      log.error("Client failure: " + message)
       requestContext.reject()
       context.stop(self)
 


### PR DESCRIPTION
Very small change to the analysis service handler classes to use the refactored ClientFailure class.
