### PR TITLE
Update Analysis Implementation

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -25,6 +25,7 @@ dm {
   ubamsResolveUrl="https://dm-ci.vault.broadinstitute.org/api/ubams/%s"
   analysesUrl="https://dm-ci.vault.broadinstitute.org/api/analyses"
   analysesResolveUrl="https://dm-ci.vault.broadinstitute.org/api/analyses/%s"
+  analysesUpdateUrl="https://dm-ci.vault.broadinstitute.org/api/analyses/%s/outputs"
   queryLookupUrl="https://dm-ci.vault.broadinstitute.org/api/query/%s/%s/%s"
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
@@ -37,6 +37,7 @@ object VaultConfig {
     def uBamResolveUrl(id: String) = dm.getString("ubamsResolveUrl").format(id)
     lazy val analysesUrl = dm.getString("analysesUrl")
     def analysesResolveUrl(id: String) = dm.getString("analysesResolveUrl").format(id)
+    def analysesUpdateUrl(id: String) = dm.getString("analysesUpdateUrl").format(id)
     def queryLookupUrl(entityType: String, attributeName: String, attributeValue: String) = dm.getString("queryLookupUrl").format(entityType, attributeName, attributeValue)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
@@ -24,7 +24,7 @@ class VaultServiceActor extends HttpServiceActor with ActorLogging {
   val uBAMDescribe = new uBAM.DescribeService with ActorRefFactoryContext
   val uBAMRedirect = new uBAM.RedirectService with ActorRefFactoryContext
 
-  val analysisIngest = new analysis.IngestService with ActorRefFactoryContext
+  val analysisIngest = new analysis.IngestAnalysisService with ActorRefFactoryContext
   val analysisDescribe = new analysis.DescribeService with ActorRefFactoryContext
   val analysisUpdate = new analysis.UpdateService with ActorRefFactoryContext
 
@@ -44,7 +44,7 @@ class VaultServiceActor extends HttpServiceActor with ActorLogging {
       typeOf[uBAM.IngestService],
       typeOf[uBAM.DescribeService],
       typeOf[uBAM.RedirectService],
-      typeOf[analysis.IngestService],
+      typeOf[analysis.IngestAnalysisService],
       typeOf[analysis.DescribeService],
       typeOf[analysis.UpdateService],
       typeOf[lookup.LookupService])

--- a/src/main/scala/org/broadinstitute/dsde/vault/model/Analysis.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/model/Analysis.scala
@@ -11,6 +11,7 @@ object AnalysisJsonProtocol extends DefaultJsonProtocol {
   implicit val impAnalysis = jsonFormat4(Analysis)
   implicit val impAnalysisResponse = jsonFormat1(AnalysisIngestResponse)
   implicit val impAnalysisUpdate = jsonFormat1(AnalysisUpdate)
+  implicit val impAnalysisDMUpdate = jsonFormat2(AnalysisDMUpdate)
 }
 
 @ApiModel(value = "An Analysis")
@@ -38,3 +39,8 @@ case class AnalysisUpdate(
   @(ApiModelProperty@field)(required = true, value = "The files associated with this Analysis, each with a unique user-supplied string key.")
   files: Map[String, String])
 
+case class AnalysisDMUpdate(
+   @(ApiModelProperty@field)(required = true, value = "The files associated with this Analysis, each with a unique user-supplied string key.")
+   files: Map[String, String],
+   @(ApiModelProperty@field)(required = true, value = "The metadata key-value pairs associated with this Analysis.")
+   metadata: Map[String, String])

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestAnalysisService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestAnalysisService.scala
@@ -7,7 +7,7 @@ import spray.http.MediaTypes._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
-trait IngestService extends HttpService {
+trait IngestAnalysisService extends HttpService {
 
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
   import spray.httpx.SprayJsonSupport._

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
@@ -1,0 +1,44 @@
+package org.broadinstitute.dsde.vault.services.analysis
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.event.Logging
+import org.broadinstitute.dsde.vault.DmClientService
+import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisUpdated
+import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
+import org.broadinstitute.dsde.vault.model.AnalysisUpdate
+import org.broadinstitute.dsde.vault.services.ClientFailure
+import org.broadinstitute.dsde.vault.services.analysis.UpdateServiceHandler.UpdateMessage
+import spray.httpx.SprayJsonSupport._
+import spray.routing.RequestContext
+
+object UpdateServiceHandler {
+
+  case class UpdateMessage(dmId: String, update: AnalysisUpdate)
+
+  def props(requestContext: RequestContext, dmService: ActorRef): Props =
+    Props(new UpdateServiceHandler(requestContext, dmService))
+
+}
+
+case class UpdateServiceHandler(requestContext: RequestContext, dmService: ActorRef) extends Actor {
+
+  implicit val system = context.system
+  val log = Logging(system, getClass)
+
+  override def receive: Receive = {
+
+    case UpdateMessage(dmId: String, update: AnalysisUpdate) =>
+      dmService ! DmClientService.DMUpdateAnalysis(dmId, update)
+
+    case DMAnalysisUpdated(analysis) =>
+      requestContext.complete(analysis)
+      context.stop(self)
+
+    case ClientFailure(message: String) =>
+      log.error("Client failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -6,7 +6,7 @@ import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 
-class AnalysisIngestServiceSpec extends VaultFreeSpec with IngestService {
+class AnalysisIngestServiceSpec extends VaultFreeSpec with IngestAnalysisService {
 
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisIngest
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisIngestResponse

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
@@ -1,52 +1,64 @@
 package org.broadinstitute.dsde.vault.services.analysis
 
 import org.broadinstitute.dsde.vault.VaultFreeSpec
-import org.broadinstitute.dsde.vault.model.AnalysisUpdate
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
+import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
+import org.broadinstitute.dsde.vault.services.uBAM.IngestService
+import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
-import spray.http.{ContentType, HttpEntity, MediaTypes, StatusCodes}
+import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 import spray.httpx.SprayJsonSupport._
 
-class AnalysisUpdateServiceSpec extends VaultFreeSpec with UpdateService {
+class AnalysisUpdateServiceSpec extends VaultFreeSpec with UpdateService with IngestService {
+
+  override val routes = updateRoute
 
   def actorRefFactory = system
 
-  val testId = "123-456-789"
+  val openAmResponse = getOpenAmToken.get
+
+  var testDataGuid: String = "invalid-id"
+  val analysisUpdate = new AnalysisUpdate(files = Map("vcf" -> "vcfValue", "bam" -> "bamValue"))
   val path = s"/analyses/%s/outputs"
 
   "AnalysisUpdateService" - {
+
+    "while preparing the ubam test data" - {
+      "should successfully store the data" in {
+        val files = Map(("bam", "/path/to/ingest/bam"))
+        val metadata = Map("ownerId" -> "user")
+        val ubamIngest = new UBamIngest(files, metadata)
+        Post("/ubams", ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+          status should equal(OK)
+          testDataGuid = responseAs[UBamIngestResponse].id
+        }
+      }
+    }
+
     "when calling POST to the " + path + " path with a valid Vault ID and valid body" - {
-      "should return as Accepted" in {
-        // TODO: figure out how to pick a valid id. Currently, all IDs will pass this stub test, which is incorrect.
-        val validId = "123-456-789"
-        val analysisUpdate = new AnalysisUpdate(
-          files = Map("vcf" -> "vcfValue", "bam" -> "bamValue")
-        )
-        Post(path.format(validId), analysisUpdate) ~> updateRoute ~> check {
-          status should equal(Accepted)
+      "should return as OK" in {
+        Post(path.format(testDataGuid), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+          status should equal(OK)
+          responseAs[Analysis]
+          responseAs[Analysis].id should be (testDataGuid)
+          responseAs[Analysis].files should equal (Some(analysisUpdate.files))
         }
       }
     }
 
-    // TODO: this test will fail until the service is properly implemented
-    "AnalysisUpdateService" - {
-      "when calling POST to the " + path + " path with an invalid Vault ID and valid body" - {
-        "should return a Not Found error" ignore {
-          val analysisUpdate = new AnalysisUpdate(
-            files = Map("vcf" -> "vcfValue", "bam" -> "bamValue")
-          )
-          Post(path.format("unknown-not-found-id"), analysisUpdate) ~> updateRoute ~> check {
-            status should equal(NotFound)
-          }
+    "when calling POST to the " + path + " path with an invalid Vault ID and valid body" - {
+      "should return a Not Found error" in {
+        Post(path.format("unknown-not-found-id"), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
+          status should equal(NotFound)
         }
       }
     }
 
-    // TODO: this test will fail until the service is properly implemented
     "when calling POST to the " + path + " path with an invalid body" - {
-      "should return a Bad Request error" ignore {
+      "should return a Bad Request error" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(path.format(testId), malformedEntity) ~> updateRoute ~> check {
+        Post(path.format(testDataGuid), malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -54,7 +66,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with UpdateService {
 
     "when calling PUT to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Put(path.format(testId)) ~> sealRoute(updateRoute) ~> check {
+        Put(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }
@@ -63,7 +75,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with UpdateService {
 
     "when calling GET to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Get(path.format(testId)) ~> sealRoute(updateRoute) ~> check {
+        Get(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }


### PR DESCRIPTION
Notable details:
- DmClientService has a major hack at the moment. DM requires that for analysis updates, a metadata key of "ownerId" must exist. However, the API layer is required to ignore any passed in metadata. Therefore, to facilitate a successful response, the updateAnalysis method adds in this required key. There is a current sprint story (https://broadinstitute.atlassian.net/browse/DSDEV-1819) to handle this with a lookup to OpenAM so this hack will need to be removed for that story.
- Needed to rename the analysis IngestService to avoid some kind of route/import/name (?) collision in the test since the test needs to access ubam.IngestService to create a ubam to work with. 
