### PR TITLE
Re-format a lot of the imports we use for implicits for consistency

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/BossClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/BossClientService.scala
@@ -2,11 +2,14 @@ package org.broadinstitute.dsde.vault
 
 import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
+import org.broadinstitute.dsde.vault.BossClientService._
+import org.broadinstitute.dsde.vault.model.BossJsonProtocol._
 import org.broadinstitute.dsde.vault.model.{BossCreationObject, BossResolutionRequest, BossResolutionResponse}
 import org.broadinstitute.dsde.vault.services.ClientFailure
 import spray.client.pipelining._
 import spray.http.BasicHttpCredentials
 import spray.http.HttpHeaders.Cookie
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
 
 import scala.util.{Failure, Success}
@@ -21,10 +24,6 @@ object BossClientService {
 }
 
 case class BossClientService(requestContext: RequestContext) extends Actor {
-
-  import org.broadinstitute.dsde.vault.BossClientService._
-  import org.broadinstitute.dsde.vault.model.BossJsonProtocol._
-  import spray.httpx.SprayJsonSupport._
 
   implicit val system = context.system
   import system.dispatcher

--- a/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
@@ -5,10 +5,15 @@ import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
 import akka.util.Timeout
+import org.broadinstitute.dsde.vault.DmClientService._
+import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
+import org.broadinstitute.dsde.vault.model.LookupJsonProtocol._
+import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
 import org.broadinstitute.dsde.vault.model.{Analysis, AnalysisIngest, EntitySearchResult, UBam, UBamIngest, _}
 import org.broadinstitute.dsde.vault.services.ClientFailure
 import spray.client.pipelining._
 import spray.http.HttpHeaders.Cookie
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
 
 import scala.util.{Failure, Success}
@@ -34,11 +39,6 @@ object DmClientService {
 
 case class DmClientService(requestContext: RequestContext) extends Actor {
 
-  import org.broadinstitute.dsde.vault.DmClientService._
-  import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
-  import org.broadinstitute.dsde.vault.model.LookupJsonProtocol._
-  import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
-  import spray.httpx.SprayJsonSupport._
   import system.dispatcher
 
   implicit val timeout = Timeout(5, TimeUnit.SECONDS)

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/DescribeServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/DescribeServiceHandler.scala
@@ -4,8 +4,10 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisResolved
+import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
 import org.broadinstitute.dsde.vault.services.ClientFailure
 import org.broadinstitute.dsde.vault.services.analysis.DescribeServiceHandler.DescribeMessage
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
 
 object DescribeServiceHandler {
@@ -17,8 +19,6 @@ object DescribeServiceHandler {
 
 case class DescribeServiceHandler(requestContext: RequestContext, dmService: ActorRef) extends Actor {
 
-  import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
-  import spray.httpx.SprayJsonSupport._
   implicit val system = context.system
   val log = Logging(system, getClass)
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestAnalysisService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestAnalysisService.scala
@@ -2,15 +2,15 @@ package org.broadinstitute.dsde.vault.services.analysis
 
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.DmClientService
+import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
 import org.broadinstitute.dsde.vault.model._
 import spray.http.MediaTypes._
+import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
 trait IngestAnalysisService extends HttpService {
 
-  import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
-  import spray.httpx.SprayJsonSupport._
   val routes = ingestRoute
 
   @ApiOperation(

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/IngestServiceHandler.scala
@@ -4,9 +4,11 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisCreated
+import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
 import org.broadinstitute.dsde.vault.model._
 import org.broadinstitute.dsde.vault.services.ClientFailure
 import org.broadinstitute.dsde.vault.services.analysis.IngestServiceHandler.IngestMessage
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
 
 object IngestServiceHandler {
@@ -20,8 +22,6 @@ object IngestServiceHandler {
 
 case class IngestServiceHandler(requestContext: RequestContext, dmService: ActorRef) extends Actor {
 
-  import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
-  import spray.httpx.SprayJsonSupport._
   implicit val system = context.system
   val log = Logging(system, getClass)
 


### PR DESCRIPTION
While reviewing the code for https://broadinstitute.atlassian.net/browse/DSDEV-1823, I found that our imports were very inconsistent. Cleaned those up. There is only one implicit not in o.b.d.v.model and that is for the OpenAmClient test class - I think it makes sense to leave it there as it is in the test packaging.
