### PR TITLE
Add boss file uploading and force-location option to analysis update.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateService.scala
@@ -4,7 +4,7 @@ import javax.ws.rs.Path
 
 import akka.actor.Props
 import com.wordnik.swagger.annotations._
-import org.broadinstitute.dsde.vault.DmClientService
+import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisUpdate
 import org.broadinstitute.dsde.vault.model._
 import spray.http.MediaTypes._
@@ -23,7 +23,9 @@ trait UpdateService extends HttpService {
     httpMethod = "POST",
     produces = "application/json",
     consumes = "application/json",
-    notes = "Accepts a json packet as POST. Updates the Vault analysis object with the supplied output files.")
+    notes = "Accepts a json packet as POST. Updates the Vault analysis object with the supplied output files. " +
+      "Returns the Vault ID of the created object. If a custom header of type 'X-Force-Location' has a " +
+      "case-insensitive value of 'true', then the file path locations will be used as the location of the file object.")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "Analysis Vault ID"),
     new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.vault.model.AnalysisUpdate", paramType = "body", value = "Analysis outputs to add")
@@ -38,14 +40,18 @@ trait UpdateService extends HttpService {
     path("analyses" / Segment / "outputs") {
       id => {
         post {
-          respondWithMediaType(`application/json`) {
-            entity(as[AnalysisUpdate]) {
-              update =>
-                requestContext => {
-                  val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
-                  val updateActor = actorRefFactory.actorOf(UpdateServiceHandler.props(requestContext, dmService))
-                  updateActor ! UpdateServiceHandler.UpdateMessage(id, update)
-                }
+          optionalHeaderValueByName("X-Force-Location") {
+            forceLocation =>
+            respondWithMediaType(`application/json`) {
+              entity(as[AnalysisUpdate]) {
+                update =>
+                  requestContext => {
+                    val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+                    val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
+                    val updateActor = actorRefFactory.actorOf(UpdateServiceHandler.props(requestContext, dmService, bossService))
+                    updateActor ! UpdateServiceHandler.UpdateMessage(id, update, forceLocation)
+                  }
+              }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
@@ -57,11 +57,11 @@ case class UpdateServiceHandler(requestContext: RequestContext, dmService: Actor
     case BossObjectCreated(bossObject: BossCreationObject, creationKey: String) =>
       bossObjects += creationKey -> bossObject.objectId.get
       bossService ! BossClientService.BossResolveObject(BossDefaults.getResolutionRequest("PUT"), bossObject.objectId.get, creationKey)
-      if (fileCount == bossObjects.size)
-        dmService ! DmClientService.DMUpdateAnalysis(dmId.get, new AnalysisUpdate(bossObjects))
 
     case BossObjectResolved(bossObject: BossResolutionResponse, creationKey: String) =>
       bossURLs += creationKey -> bossObject.objectUrl
+      if (fileCount == bossObjects.size)
+        dmService ! DmClientService.DMUpdateAnalysis(dmId.get, new AnalysisUpdate(bossObjects))
 
     case DMAnalysisUpdated(analysis) =>
       requestContext.complete(new Analysis(dmId.get, analysis.input, analysis.metadata, Option(bossURLs)))

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/UpdateServiceHandler.scala
@@ -2,10 +2,11 @@ package org.broadinstitute.dsde.vault.services.analysis
 
 import akka.actor.{Actor, ActorRef, Props}
 import akka.event.Logging
-import org.broadinstitute.dsde.vault.DmClientService
+import org.broadinstitute.dsde.vault.BossClientService.{BossObjectResolved, BossObjectCreated}
+import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import org.broadinstitute.dsde.vault.DmClientService.DMAnalysisUpdated
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
-import org.broadinstitute.dsde.vault.model.AnalysisUpdate
+import org.broadinstitute.dsde.vault.model._
 import org.broadinstitute.dsde.vault.services.ClientFailure
 import org.broadinstitute.dsde.vault.services.analysis.UpdateServiceHandler.UpdateMessage
 import spray.httpx.SprayJsonSupport._
@@ -13,25 +14,57 @@ import spray.routing.RequestContext
 
 object UpdateServiceHandler {
 
-  case class UpdateMessage(dmId: String, update: AnalysisUpdate)
+  case class UpdateMessage(dmId: String, update: AnalysisUpdate, forceLocation: Option[String] = None)
 
-  def props(requestContext: RequestContext, dmService: ActorRef): Props =
-    Props(new UpdateServiceHandler(requestContext, dmService))
+  def props(requestContext: RequestContext, dmService: ActorRef, bossService: ActorRef): Props =
+    Props(new UpdateServiceHandler(requestContext, dmService, bossService))
 
 }
 
-case class UpdateServiceHandler(requestContext: RequestContext, dmService: ActorRef) extends Actor {
+case class UpdateServiceHandler(requestContext: RequestContext, dmService: ActorRef, bossService: ActorRef) extends Actor {
 
   implicit val system = context.system
   val log = Logging(system, getClass)
 
+  // the number of files associated with this analysis
+  // set by AnalysisUpdate
+  var fileCount: Integer = _
+
+  // a map from file types to Boss IDs
+  // added by BossObjectCreated messages (1 per message)
+  // consumed by DmClientService.DMUpdateAnalysis after [fileCount] have been added
+  var bossObjects: Map[String, String] = Map.empty
+
+  // a map from file types to Presigned Boss PUT URLs
+  // added by BossObjectResolved messages (1 per message)
+  // consumed by DMAnalysisUpdated after [fileCount] have been added and the DM ID has been set
+  var bossURLs: Map[String, String] = Map.empty
+
+  // the DM ID for this analysis
+  // set by UpdateMessage
+  var dmId: Option[String] = None
+
   override def receive: Receive = {
 
-    case UpdateMessage(dmId: String, update: AnalysisUpdate) =>
-      dmService ! DmClientService.DMUpdateAnalysis(dmId, update)
+    case UpdateMessage(id: String, update: AnalysisUpdate, forceLocation: Option[String]) =>
+      dmId = Some(id)
+      fileCount = update.files.size
+      update.files.foreach {
+        case (ftype, fpath) =>
+          bossService ! BossClientService.BossCreateObject(BossDefaults.getCreationRequest(fpath, forceLocation), ftype)
+      }
+
+    case BossObjectCreated(bossObject: BossCreationObject, creationKey: String) =>
+      bossObjects += creationKey -> bossObject.objectId.get
+      bossService ! BossClientService.BossResolveObject(BossDefaults.getResolutionRequest("PUT"), bossObject.objectId.get, creationKey)
+      if (fileCount == bossObjects.size)
+        dmService ! DmClientService.DMUpdateAnalysis(dmId.get, new AnalysisUpdate(bossObjects))
+
+    case BossObjectResolved(bossObject: BossResolutionResponse, creationKey: String) =>
+      bossURLs += creationKey -> bossObject.objectUrl
 
     case DMAnalysisUpdated(analysis) =>
-      requestContext.complete(analysis)
+      requestContext.complete(new Analysis(dmId.get, analysis.input, analysis.metadata, Option(bossURLs)))
       context.stop(self)
 
     case ClientFailure(message: String) =>


### PR DESCRIPTION
This PR implements the same force-location header semantics as found in UBam ingest. It also now correctly sets up a BOSS file for each analysis file.