### PR TITLE
Renaming to avoid future name collisions

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
@@ -20,14 +20,14 @@ class VaultServiceActor extends HttpServiceActor with ActorLogging {
     def actorRefFactory = context
   }
 
-  val uBAMIngest = new uBAM.IngestService with ActorRefFactoryContext
-  val uBAMDescribe = new uBAM.DescribeService with ActorRefFactoryContext
-  val uBAMRedirect = new uBAM.RedirectService with ActorRefFactoryContext
+  val uBAMIngest = new uBAM.UBamIngestService with ActorRefFactoryContext
+  val uBAMDescribe = new uBAM.UBamDescribeService with ActorRefFactoryContext
+  val uBAMRedirect = new uBAM.UBamRedirectService with ActorRefFactoryContext
 
-  val analysisIngest = new analysis.IngestAnalysisService with ActorRefFactoryContext
-  val analysisDescribe = new analysis.DescribeService with ActorRefFactoryContext
-  val analysisUpdate = new analysis.UpdateService with ActorRefFactoryContext
-  val analysisRedirect = new analysis.RedirectService with ActorRefFactoryContext
+  val analysisIngest = new analysis.AnalysisIngestService with ActorRefFactoryContext
+  val analysisDescribe = new analysis.AnalysisDescribeService with ActorRefFactoryContext
+  val analysisUpdate = new analysis.AnalysisUpdateService with ActorRefFactoryContext
+  val analysisRedirect = new analysis.AnalysisRedirectService with ActorRefFactoryContext
 
   val lookupService = new lookup.LookupService with ActorRefFactoryContext
 
@@ -42,13 +42,13 @@ class VaultServiceActor extends HttpServiceActor with ActorLogging {
   val swaggerService = new SwaggerHttpService {
     // All documented API services must be added to these API types
     override def apiTypes = Seq(
-      typeOf[uBAM.IngestService],
-      typeOf[uBAM.DescribeService],
-      typeOf[uBAM.RedirectService],
-      typeOf[analysis.IngestAnalysisService],
-      typeOf[analysis.DescribeService],
-      typeOf[analysis.UpdateService],
-      typeOf[analysis.RedirectService],
+      typeOf[uBAM.UBamIngestService],
+      typeOf[uBAM.UBamDescribeService],
+      typeOf[uBAM.UBamRedirectService],
+      typeOf[analysis.AnalysisIngestService],
+      typeOf[analysis.AnalysisDescribeService],
+      typeOf[analysis.AnalysisUpdateService],
+      typeOf[analysis.AnalysisRedirectService],
       typeOf[lookup.LookupService])
 
     override def apiVersion = VaultConfig.SwaggerConfig.apiVersion

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
@@ -8,7 +8,7 @@ import spray.http.MediaTypes._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
-trait DescribeService extends HttpService {
+trait AnalysisDescribeService extends HttpService {
 
   val routes = describeRoute
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
@@ -10,7 +10,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
 trait AnalysisDescribeService extends HttpService {
 
-  val routes = describeRoute
+  val routes = analysisDescribeRoute
 
   @ApiOperation(value = "Describes an Analysis' metadata, inputs, and output files.  Does not generate presigned URLs.",
     nickname = "analysis_describe",
@@ -27,7 +27,7 @@ trait AnalysisDescribeService extends HttpService {
     new ApiResponse(code = 404, message = "Vault ID Not Found"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def describeRoute = {
+  def analysisDescribeRoute = {
     path("analyses" / Segment) {
       id => {
         get {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
@@ -9,7 +9,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
-trait IngestAnalysisService extends HttpService {
+trait AnalysisIngestService extends HttpService {
 
   val routes = ingestRoute
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
@@ -11,7 +11,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
 trait AnalysisIngestService extends HttpService {
 
-  val routes = ingestRoute
+  val routes = analysisIngestRoute
 
   @ApiOperation(
     value = "Creates Analysis objects",
@@ -30,7 +30,7 @@ trait AnalysisIngestService extends HttpService {
     new ApiResponse(code = 400, message = "Malformed Input"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def ingestRoute =
+  def analysisIngestRoute =
     path("analyses") {
       post {
         respondWithMediaType(`application/json`) {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
@@ -1,20 +1,20 @@
-package org.broadinstitute.dsde.vault.services.uBAM
+package org.broadinstitute.dsde.vault.services.analysis
 
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import spray.routing._
 
-@Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
-trait RedirectService extends HttpService {
+@Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 0)
+trait AnalysisRedirectService extends HttpService {
 
   val routes = redirectRoute
 
-  @ApiOperation(value = "Redirects to presigned GET URLs for uBAM files", nickname = "ubam_redirect", httpMethod = "GET",
-    notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified uBAM file. If the caller would like presigned URLs to all files within an object, " +
+  @ApiOperation(value = "Redirects to presigned GET URLs for analyses", nickname = "analysis_redirect", httpMethod = "GET",
+    notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified analysis output file. If the caller would like presigned URLs to all files within an analysis, " +
       "it is the caller's responsibility to make multiple requests to this API - one for each file.")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "uBAM Vault ID"),
-    new ApiImplicitParam(name = "filetype", required = true, dataType = "string", paramType = "path", value = "The user-specified unique key for this file, e.g. 'bam' or 'bai'")
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "Analysis Vault ID"),
+    new ApiImplicitParam(name = "filetype", required = true, dataType = "string", paramType = "path", value = "The user-specified unique key for this file, e.g. 'bam' or 'vcf'")
   ))
   @ApiResponses(Array(
     new ApiResponse(code = 307, message = "Redirected"),
@@ -23,7 +23,7 @@ trait RedirectService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def redirectRoute =
-    path("ubams" / Segment / Segment) {
+    path("analyses" / Segment / Segment) {
       (id, filetype) =>
         get {
           requestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
@@ -7,7 +7,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 0)
 trait AnalysisRedirectService extends HttpService {
 
-  val routes = redirectRoute
+  val routes = analysisRedirectRoute
 
   @ApiOperation(value = "Redirects to presigned GET URLs for analyses", nickname = "analysis_redirect", httpMethod = "GET",
     notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified analysis output file. If the caller would like presigned URLs to all files within an analysis, " +
@@ -22,7 +22,7 @@ trait AnalysisRedirectService extends HttpService {
     new ApiResponse(code = 404, message = "Vault ID Not Found"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def redirectRoute =
+  def analysisRedirectRoute =
     path("analyses" / Segment / Segment) {
       (id, filetype) =>
         get {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
@@ -14,7 +14,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 1)
 trait AnalysisUpdateService extends HttpService {
 
-  val routes = updateRoute
+  val routes = analysisUpdateRoute
 
   @Path("/{id}/outputs")
   @ApiOperation(
@@ -37,7 +37,7 @@ trait AnalysisUpdateService extends HttpService {
     new ApiResponse(code = 404, message = "Vault ID Not Found"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def updateRoute =
+  def analysisUpdateRoute =
     path("analyses" / Segment / "outputs") {
       id => {
         post {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
@@ -12,7 +12,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 1)
-trait UpdateService extends HttpService {
+trait AnalysisUpdateService extends HttpService {
 
   val routes = updateRoute
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
@@ -10,7 +10,7 @@ import spray.routing._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamDescribeService extends HttpService {
 
-  val routes = describeRoute
+  val routes = uBamDescribeRoute
 
   @ApiOperation(value = "Describes a uBAM's metadata and associated files.  Does not generate presigned URLs.",
     nickname = "ubam_describe",
@@ -26,7 +26,7 @@ trait UBamDescribeService extends HttpService {
     new ApiResponse(code = 404, message = "Vault ID Not Found"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def describeRoute = {
+  def uBamDescribeRoute = {
     path("ubams" / Segment) {
       id =>
         get {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.vault.model._
 import spray.routing._
 
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
-trait DescribeService extends HttpService {
+trait UBamDescribeService extends HttpService {
 
   val routes = describeRoute
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
@@ -12,7 +12,7 @@ import uBAMJsonProtocol._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamIngestService extends HttpService {
 
-  val routes = ingestRoute
+  val routes = uBamIngestRoute
 
   @ApiOperation(
     value = "Creates uBAM objects",
@@ -33,7 +33,7 @@ trait UBamIngestService extends HttpService {
     new ApiResponse(code = 400, message = "Malformed Input"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def ingestRoute =
+  def uBamIngestRoute =
     path("ubams") {
       post {
         optionalHeaderValueByName("X-Force-Location") {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
@@ -10,7 +10,7 @@ import spray.httpx.SprayJsonSupport._
 import uBAMJsonProtocol._
 
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
-trait IngestService extends HttpService {
+trait UBamIngestService extends HttpService {
 
   val routes = ingestRoute
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
@@ -7,7 +7,7 @@ import spray.routing._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamRedirectService extends HttpService {
 
-  val routes = redirectRoute
+  val routes = uBamRedirectRoute
 
   @ApiOperation(value = "Redirects to presigned GET URLs for uBAM files", nickname = "ubam_redirect", httpMethod = "GET",
     notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified uBAM file. If the caller would like presigned URLs to all files within an object, " +
@@ -22,7 +22,7 @@ trait UBamRedirectService extends HttpService {
     new ApiResponse(code = 404, message = "Vault ID Not Found"),
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
-  def redirectRoute =
+  def uBamRedirectRoute =
     path("ubams" / Segment / Segment) {
       (id, filetype) =>
         get {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
@@ -1,20 +1,20 @@
-package org.broadinstitute.dsde.vault.services.analysis
+package org.broadinstitute.dsde.vault.services.uBAM
 
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import spray.routing._
 
-@Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 0)
-trait RedirectService extends HttpService {
+@Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
+trait UBamRedirectService extends HttpService {
 
   val routes = redirectRoute
 
-  @ApiOperation(value = "Redirects to presigned GET URLs for analyses", nickname = "analysis_redirect", httpMethod = "GET",
-    notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified analysis output file. If the caller would like presigned URLs to all files within an analysis, " +
+  @ApiOperation(value = "Redirects to presigned GET URLs for uBAM files", nickname = "ubam_redirect", httpMethod = "GET",
+    notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified uBAM file. If the caller would like presigned URLs to all files within an object, " +
       "it is the caller's responsibility to make multiple requests to this API - one for each file.")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "Analysis Vault ID"),
-    new ApiImplicitParam(name = "filetype", required = true, dataType = "string", paramType = "path", value = "The user-specified unique key for this file, e.g. 'bam' or 'vcf'")
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "uBAM Vault ID"),
+    new ApiImplicitParam(name = "filetype", required = true, dataType = "string", paramType = "path", value = "The user-specified unique key for this file, e.g. 'bam' or 'bai'")
   ))
   @ApiResponses(Array(
     new ApiResponse(code = 307, message = "Redirected"),
@@ -23,7 +23,7 @@ trait RedirectService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def redirectRoute =
-    path("analyses" / Segment / Segment) {
+    path("ubams" / Segment / Segment) {
       (id, filetype) =>
         get {
           requestContext =>

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
@@ -11,7 +11,7 @@ import spray.httpx.unmarshalling._
 
 class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeService with AnalysisUpdateService with AnalysisIngestService {
 
-  override val routes = describeRoute
+  override val routes = analysisDescribeRoute
 
   def actorRefFactory = system
 
@@ -27,7 +27,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
           input = List(),
           metadata = Map("ownerId" -> "testUser", "randomData" -> "7")
         )
-        Post(ingestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(ingestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           val respAnalysis = responseAs[AnalysisIngestResponse]
           testId = respAnalysis.id
@@ -37,7 +37,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the " + path + " path with a Vault ID" - {
       "should return that ID" in {
-        Get(path + "/" + testId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> describeRoute ~> check {
+        Get(path + "/" + testId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisDescribeRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include(testId)
@@ -57,7 +57,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
       "should return as OK" in {
         val updatePath = s"/analyses/%s/outputs"
         val analysisUpdate = new AnalysisUpdate(files = Map("vcf" -> "path/to/ingest/vcf", "bai" -> "path/to/ingest/bai", "bam" -> "path/to/ingest/bam"))
-        Post(updatePath.format(testId), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+        Post(updatePath.format(testId), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val analysisResponse = responseAs[Analysis]
           val files = responseAs[Analysis].files
@@ -71,7 +71,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the " + path + " path with a Vault ID" - {
       "should reference the new files" in {
-        Get(path + "/" + testId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> describeRoute ~> check {
+        Get(path + "/" + testId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisDescribeRoute ~> check {
           status should equal(OK)
           val respAnalysis = responseAs[Analysis]
           respAnalysis.id should equal(testId)
@@ -88,7 +88,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the " + path + " path with an invalid Vault ID" - {
       "should return a Not Found error" in {
-        Get(path + "/" + "unknown-not-found-id") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(describeRoute) ~> check {
+        Get(path + "/" + "unknown-not-found-id") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisDescribeRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -96,7 +96,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling PUT to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(path + "/" + testId) ~> sealRoute(describeRoute) ~> check {
+        Put(path + "/" + testId) ~> sealRoute(analysisDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -105,7 +105,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling POST to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(path + "/" + testId) ~> sealRoute(describeRoute) ~> check {
+        Post(path + "/" + testId) ~> sealRoute(analysisDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
@@ -9,7 +9,7 @@ import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.httpx.unmarshalling._
 
-class AnalysisDescribeServiceSpec extends VaultFreeSpec with DescribeService with UpdateService with IngestAnalysisService {
+class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeService with AnalysisUpdateService with AnalysisIngestService {
 
   override val routes = describeRoute
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -6,7 +6,7 @@ import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 
-class AnalysisIngestServiceSpec extends VaultFreeSpec with IngestAnalysisService {
+class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService {
 
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisIngest
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisIngestResponse

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -23,7 +23,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = List(),
           metadata = Map("ownerId" -> "testUser", "randomData" -> "7")
         )
-        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include("id")
@@ -38,7 +38,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
     "when calling POST to the " + path + " path with invalid input" - {
       "should return a Bad Request error" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(path, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(ingestRoute) ~> check {
+        Post(path, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -47,7 +47,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
 
     "when calling PUT to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Put(path) ~> sealRoute(ingestRoute) ~> check {
+        Put(path) ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }
@@ -56,7 +56,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
 
     "when calling GET to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Get(path) ~> sealRoute(ingestRoute) ~> check {
+        Get(path) ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
@@ -8,7 +8,7 @@ import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 
-class AnalysisRedirectServiceSpec extends VaultFreeSpec with RedirectService with IngestAnalysisService with UpdateService {
+class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectService with AnalysisIngestService with AnalysisUpdateService {
 
   override val routes = redirectRoute
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
@@ -10,7 +10,7 @@ import spray.httpx.SprayJsonSupport._
 
 class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectService with AnalysisIngestService with AnalysisUpdateService {
 
-  override val routes = redirectRoute
+  override val routes = analysisRedirectRoute
 
   def actorRefFactory = system
   val path = "/analyses"
@@ -26,7 +26,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
     "while preparing the analysis test data" - {
       "should successfully store the data" in {
         val analysisIngest = new AnalysisIngest(inputs, metadata)
-        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[Analysis].id
           responseAs[Analysis].metadata.getOrElse("ownerId", "get failed") should equal("user")
@@ -34,7 +34,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
       }
       "should successfully update the data" in {
         val analysisUpdate = new AnalysisUpdate(files)
-        Post(path + "/" + testingId + "/outputs", analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+        Post(path + "/" + testingId + "/outputs", analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val analysisResponse = responseAs[Analysis]
           val files = responseAs[Analysis].files
@@ -48,7 +48,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "when calling GET to the " + path + " path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(TemporaryRedirect)
         }
       }
@@ -56,7 +56,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "when calling GET to the " + path + " path with a valid Vault ID and an invalid file type" - {
       "should return a Bad Request response" in {
-        Get(path + "/" + testingId + "/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/" + testingId + "/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -64,7 +64,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "when calling GET to the " + path + " path with an invalid Vault ID and a valid file type" - {
       "should return a a Not Found response" in {
-        Get(path + "/12345-67890-12345/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/12345-67890-12345/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -72,7 +72,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "when calling PUT to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Put(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -81,7 +81,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "when calling POST to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Post(path + "/" + testingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -91,7 +91,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
     "X-Force-Location API: while preparing the analysis test data" - {
       "should successfully store the data" in {
         val analysisIngest = new AnalysisIngest(inputs, metadata)
-        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           forceTestingId = responseAs[Analysis].id
           responseAs[Analysis].metadata.getOrElse("ownerId", "get failed") should equal("user")
@@ -99,7 +99,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
       }
       "should successfully update the data" in {
         val analysisUpdate = new AnalysisUpdate(files)
-        Post(path + "/" + forceTestingId + "/outputs", analysisUpdate) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+        Post(path + "/" + forceTestingId + "/outputs", analysisUpdate) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val analysisResponse = responseAs[Analysis]
           val files = responseAs[Analysis].files
@@ -112,7 +112,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
 
     "X-Force-Location API: when calling GET to the " + path + " path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(path + "/" + forceTestingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/" + forceTestingId + "/bam") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisRedirectRoute) ~> check {
           status should equal(TemporaryRedirect)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
@@ -12,7 +12,7 @@ import spray.httpx.SprayJsonSupport._
 
 class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService with UBamIngestService {
 
-  override val routes = updateRoute
+  override val routes = analysisUpdateRoute
 
   def actorRefFactory = system
 
@@ -29,7 +29,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
         val files = Map(("bam", "/path/to/ingest/bam"))
         val metadata = Map("ownerId" -> "user")
         val ubamIngest = new UBamIngest(files, metadata)
-        Post("/ubams", ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post("/ubams", ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testDataGuid = responseAs[UBamIngestResponse].id
         }
@@ -38,7 +38,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
 
     "when calling POST to the " + path + " path with a valid Vault ID and valid body" - {
       "should return as OK" in {
-        Post(path.format(testDataGuid), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+        Post(path.format(testDataGuid), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val analysisResponse = responseAs[Analysis]
           val files = responseAs[Analysis].files
@@ -52,7 +52,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
 
     "when calling POST to the " + path + " path with a Analysis object and 'X-Force-Location' header" - {
       "should return a valid response with paths as part of the file path names" in {
-        Post(path.format(testDataGuid), analysisUpdate) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> updateRoute ~> check {
+        Post(path.format(testDataGuid), analysisUpdate) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val files = responseAs[Analysis].files
           files.get("bam") should equal("path/to/ingest/bam")
@@ -64,7 +64,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
 
     "when calling POST to the " + path + " path with an invalid Vault ID and valid body" - {
       "should return a Not Found error" in {
-        Post(path.format("unknown-not-found-id"), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
+        Post(path.format("unknown-not-found-id"), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisUpdateRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -73,7 +73,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
     "when calling POST to the " + path + " path with an invalid body" - {
       "should return a Bad Request error" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(path.format(testDataGuid), malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
+        Post(path.format(testDataGuid), malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisUpdateRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -81,7 +81,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
 
     "when calling PUT to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Put(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
+        Put(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisUpdateRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }
@@ -90,7 +90,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
 
     "when calling GET to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Get(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(updateRoute) ~> check {
+        Get(path.format(testDataGuid)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisUpdateRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
@@ -4,13 +4,13 @@ import org.broadinstitute.dsde.vault.VaultFreeSpec
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
 import org.broadinstitute.dsde.vault.model._
 import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
-import org.broadinstitute.dsde.vault.services.uBAM.IngestService
+import org.broadinstitute.dsde.vault.services.uBAM.UBamIngestService
 import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 import spray.httpx.SprayJsonSupport._
 
-class AnalysisUpdateServiceSpec extends VaultFreeSpec with UpdateService with IngestService {
+class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService with UBamIngestService {
 
   override val routes = updateRoute
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
@@ -28,7 +28,7 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
         val files = Map(("bam", "/path/to/ingest/bam"), ("bai", "/path/to/ingest/bai"))
         val metadata = Map("ownerId" -> "user", "uniqueTest" -> testValue)
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testDataGuid = responseAs[UBamIngestResponse].id
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
@@ -4,13 +4,13 @@ import org.broadinstitute.dsde.vault.VaultFreeSpec
 import org.broadinstitute.dsde.vault.model.{UBamIngestResponse, UBamIngest, EntitySearchResult}
 import org.broadinstitute.dsde.vault.model.LookupJsonProtocol._
 import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
-import org.broadinstitute.dsde.vault.services.uBAM.IngestService
+import org.broadinstitute.dsde.vault.services.uBAM.UBamIngestService
 import spray.http.HttpCookie
 import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 
-class LookupServiceSpec extends VaultFreeSpec with LookupService with IngestService {
+class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngestService {
 
   override val routes = lookupRoute
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
@@ -9,7 +9,7 @@ import spray.http.StatusCodes._
 import spray.httpx.unmarshalling._
 import spray.httpx.SprayJsonSupport._
 
-class DescribeServiceSpec extends VaultFreeSpec with DescribeService with IngestService {
+class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UBamIngestService {
 
   override val routes = describeRoute
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
@@ -1,12 +1,11 @@
 package org.broadinstitute.dsde.vault.services.uBAM
 
 import org.broadinstitute.dsde.vault.VaultFreeSpec
-import org.broadinstitute.dsde.vault.model.{UBamIngestResponse, UBamIngest, UBam, uBAMJsonProtocol}
+import org.broadinstitute.dsde.vault.model.{UBamIngestResponse, UBamIngest, UBam}
 import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
 import spray.http.HttpCookie
 import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
-import spray.httpx.unmarshalling._
 import spray.httpx.SprayJsonSupport._
 
 class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UBamIngestService {

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
@@ -11,7 +11,7 @@ import spray.httpx.SprayJsonSupport._
 
 class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UBamIngestService {
 
-  override val routes = describeRoute
+  override val routes = uBamDescribeRoute
 
   def actorRefFactory = system
   val path = "/ubams"
@@ -25,7 +25,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
     "while preparing the ubam test data" - {
       "should successfully store the data" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[UBamIngestResponse].id
         }
@@ -34,7 +34,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
 
     "when calling GET to the " + path + " path with a Vault ID" - {
       "should return that ID" in {
-        Get(path + "/" + testingId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> describeRoute ~> check {
+        Get(path + "/" + testingId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamDescribeRoute ~> check {
           status should equal(OK)
           val response = responseAs[UBam]
           response.id should be(testingId)
@@ -49,7 +49,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
 
     "when calling GET to the " + path + " path with an unknown Vault ID" - {
       "should return a 404 not found error" in {
-        Get(path + "/12345-67890-12345") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(describeRoute) ~> check {
+        Get(path + "/12345-67890-12345") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -57,7 +57,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
 
     "when calling PUT to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(path + "/" + testingId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(describeRoute) ~> check {
+        Put(path + "/" + testingId) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -66,7 +66,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
 
     "when calling POST to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(path + "/arbitrary_id") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(describeRoute) ~> check {
+        Post(path + "/arbitrary_id") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
@@ -8,7 +8,7 @@ import spray.http.StatusCodes._
 import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 import spray.httpx.SprayJsonSupport._
 
-class IngestServiceSpec extends VaultFreeSpec with IngestService {
+class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
   def actorRefFactory = system
   val path = "/ubams"

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
@@ -24,7 +24,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
     "when calling POST to the " + path + " path with a UBamIngest object" - {
       "should return a valid response" in {
         // As designed, the API returns an object that only contains an id and files, but not the supplied metadata
-        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           responseAs[String] should include("bam")
           responseAs[String] should include("bai")
@@ -36,7 +36,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
     "when calling POST to the " + path + " path with a UBamIngest object and 'X-Force-Location' header" - {
       "should return a valid response with the provided file paths" in {
-        Post(path, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           val files = responseAs[UBamIngestResponse].files
           files.get("bam").get should equal("/path/to/ingest/bam")
@@ -47,7 +47,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
     "when calling GET to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Get(path) ~> sealRoute(ingestRoute) ~> check {
+        Get(path) ~> sealRoute(uBamIngestRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }
@@ -56,7 +56,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
     "when calling PUT to the " + path + " path" - {
       "should return a MethodNotAllowed error" in {
-        Put(path) ~> sealRoute(ingestRoute) ~> check {
+        Put(path) ~> sealRoute(uBamIngestRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: POST")
         }
@@ -66,7 +66,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
     "when calling POST to the " + path + " path with a malformed UBamIngest object" - {
       "should return an invalid response" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(path, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(ingestRoute) ~> check {
+        Post(path, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamIngestRoute) ~> check {
           status should equal(BadRequest)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
@@ -10,7 +10,7 @@ import spray.httpx.SprayJsonSupport._
 
 class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UBamIngestService {
 
-  override val routes = redirectRoute
+  override val routes = uBamRedirectRoute
 
   def actorRefFactory = system
   val path = "/ubams"
@@ -25,7 +25,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
     "while preparing the ubam test data" - {
       "should successfully store the data" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[UBamIngestResponse].id
         }
@@ -34,7 +34,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "when calling GET to the " + path + " path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> redirectRoute ~> check {
+        Get(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamRedirectRoute ~> check {
           status should equal(TemporaryRedirect)
         }
       }
@@ -42,7 +42,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "when calling GET to the " + path + " path with a valid Vault ID and an invalid file type" - {
       "should return a Bad Request response" in {
-        Get(path + "/" + testingId + "/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/" + testingId + "/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -50,7 +50,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "when calling GET to the " + path + " path with an invalid Vault ID and a valid file type" - {
       "should return a a Not Found response" in {
-        Get(path + "/12345-67890-12345/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Get(path + "/12345-67890-12345/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -58,7 +58,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "when calling PUT to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Put(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -67,7 +67,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "when calling POST to the " + path + " path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(redirectRoute) ~> check {
+        Post(path + "/" + testingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -77,7 +77,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
     "X-Force-Location API: while preparing the ubam test data" - {
       "should successfully store the data" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(path, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> ingestRoute ~> check {
+        Post(path, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
           forceTestingId = responseAs[UBamIngestResponse].id
           files.get("bam").get should equal("/path/to/ingest/bam")
@@ -89,7 +89,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
 
     "X-Force-Location API: when calling GET to the " + path + " path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(path + "/" + forceTestingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> redirectRoute ~> check {
+        Get(path + "/" + forceTestingId + "/bai") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamRedirectRoute ~> check {
           status should equal(TemporaryRedirect)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
@@ -8,7 +8,7 @@ import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 
-class RedirectServiceSpec extends VaultFreeSpec with RedirectService with IngestService {
+class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UBamIngestService {
 
   override val routes = redirectRoute
 


### PR DESCRIPTION
Mass renaming, e.g.
`analysis.DescribeService` -> `analysis.AnalysisDescribeService`
`analysis.DescribeService.describeRoute` -> `analysis.AnalysisDescribeService.analysisDescribeRoute`

Split into multiple commits to make it easier to see what's going on.  Happy to squash if you prefer.

I'm open to other naming schemes as well.
