### PR TITLE
fix a TODO: remove hardcoded ownerId value now that OpenAM identity is working

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
@@ -133,13 +133,11 @@ case class DmClientService(requestContext: RequestContext) extends Actor {
     }
   }
 
-  // TODO: Fix the following hack when reverse-lookup authentication service is implemented
-  // Any metadata passed in needs to be ignored. Metadata passed to DM needs to include a temporary ownerId key/value.
-  // This needs to change when authorship is appropriately determined through the authentication service.
+  // We explicitly ignore any metadata passed in from the client.
   def updateAnalysis(senderRef: ActorRef, analysisId: String, update: AnalysisUpdate): Unit = {
     log.debug("Updating an Analysis through the DM API for Analysis id: " + analysisId)
     val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive ~> unmarshal[Analysis]
-    val analysisDmUpdate = new AnalysisDMUpdate(update.files, Map("ownerId" -> "foo"))
+    val analysisDmUpdate = new AnalysisDMUpdate(update.files, Map.empty[String,String])
     val responseFuture = pipeline {
       Post(VaultConfig.DataManagement.analysesUpdateUrl(analysisId), analysisDmUpdate)
     }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
@@ -25,7 +25,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
         val ingestPath = "/analyses"
         val analysisIngest = new AnalysisIngest(
           input = List(),
-          metadata = Map("ownerId" -> "testUser", "randomData" -> "7")
+          metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
         Post(ingestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
@@ -48,7 +48,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
           respAnalysis.id should equal(testId)
           respAnalysis.input shouldBe empty
           respAnalysis.files.get shouldBe empty
-          respAnalysis.metadata should equal(Map("ownerId" -> "testUser", "randomData" -> "7"))
+          respAnalysis.metadata should equal(Map("testAttr" -> "testValue", "randomData" -> "7"))
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -21,7 +21,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
       "should return an ID" in {
         val analysisIngest = new AnalysisIngest(
           input = List(),
-          metadata = Map("ownerId" -> "testUser", "randomData" -> "7")
+          metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
         Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
@@ -19,7 +19,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
   var forceTestingId = "invalid_UUID"
 
   val inputs = List()
-  val metadata = Map("ownerId" -> "user")
+  val metadata = Map("testAttr" -> "testValue")
   val files = Map(("bam", "/path/to/outputs/bam"), ("vcf", "/path/to/outputs/vcf"))
 
   "Analysis Redirect Service" - {
@@ -29,7 +29,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
         Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[Analysis].id
-          responseAs[Analysis].metadata.getOrElse("ownerId", "get failed") should equal("user")
+          responseAs[Analysis].metadata.getOrElse("testAttr", "get failed") should equal("testValue")
         }
       }
       "should successfully update the data" in {
@@ -94,7 +94,7 @@ class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectSer
         Post(path, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
           status should equal(OK)
           forceTestingId = responseAs[Analysis].id
-          responseAs[Analysis].metadata.getOrElse("ownerId", "get failed") should equal("user")
+          responseAs[Analysis].metadata.getOrElse("testAttr", "get failed") should equal("testValue")
         }
       }
       "should successfully update the data" in {

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
@@ -27,7 +27,7 @@ class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService
     "while preparing the ubam test data" - {
       "should successfully store the data" in {
         val files = Map(("bam", "/path/to/ingest/bam"))
-        val metadata = Map("ownerId" -> "user")
+        val metadata = Map("testAttr" -> "testValue")
         val ubamIngest = new UBamIngest(files, metadata)
         Post("/ubams", ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
@@ -26,7 +26,7 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
       "should successfully store the data" in {
         val path = "/ubams"
         val files = Map(("bam", "/path/to/ingest/bam"), ("bai", "/path/to/ingest/bai"))
-        val metadata = Map("ownerId" -> "user", "uniqueTest" -> testValue)
+        val metadata = Map("testAttr" -> "testValue", "uniqueTest" -> testValue)
         val ubamIngest = new UBamIngest(files, metadata)
         Post(path, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
           status should equal(OK)
@@ -63,7 +63,7 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
       }
 
       "Lookup of mismatched attribute name + value should return not found" in {
-        Get(s"/query/ubam/ownerId/$testValue") ~> sealRoute(lookupRoute) ~> check {
+        Get(s"/query/ubam/testAttr/$testValue") ~> sealRoute(lookupRoute) ~> check {
           status === NotFound
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceSpec.scala
@@ -18,7 +18,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
   var testingId = "invalid_UUID"
 
   val files = Map(("bam", "/path/to/ingest/bam"), ("bai", "/path/to/ingest/bai"))
-  val metadata = Map("ownerId" -> "user")
+  val metadata = Map("testAttr" -> "testValue")
 
   "DescribeuBAMService" - {
     "while preparing the ubam test data" - {
@@ -37,7 +37,7 @@ class DescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UB
           status should equal(OK)
           val response = responseAs[UBam]
           response.id should be(testingId)
-          response.metadata should equal(Map("ownerId" -> "user"))
+          response.metadata should equal(Map("testAttr" -> "testValue"))
           response.files.getOrElse("bam", "error") should (be an (URL) and not be a (UUID))
           response.files.getOrElse("bai", "error") should (be an (URL) and not be a (UUID))
           response.files.getOrElse("bam", "error") shouldNot include("ingest")

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/IngestServiceSpec.scala
@@ -18,7 +18,7 @@ class IngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
     val ubamIngest = new UBamIngest(
       files = Map(("bam", "/path/to/ingest/bam"),("bai", "/path/to/ingest/bai")),
-      metadata = Map(("ownerId", "testUser"),("randomData", "7"))
+      metadata = Map(("testAttr", "testValue"),("randomData", "7"))
     )
 
     "when calling POST to the " + path + " path with a UBamIngest object" - {

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/RedirectServiceSpec.scala
@@ -19,7 +19,7 @@ class RedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UB
   var forceTestingId = "invalid_UUID"
 
   val files = Map(("bam", "/path/to/ingest/bam"), ("bai", "/path/to/ingest/bai"))
-  val metadata = Map("ownerId" -> "user")
+  val metadata = Map("testAttr" -> "testValue")
 
   "RedirectuBAMService" - {
     "while preparing the ubam test data" - {


### PR DESCRIPTION
Architecturally, another option is to make this a passthrough and send any metadata to DM, counting on DM to ignore it. I thought this was safer, but open to debate.
