### PR TITLE
reduce swagger notes to 2 lines to fix errors in sbt publish

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
@@ -23,9 +23,8 @@ trait AnalysisUpdateService extends HttpService {
     httpMethod = "POST",
     produces = "application/json",
     consumes = "application/json",
-    notes = "Accepts a json packet as POST. Updates the Vault analysis object with the supplied output files. " +
-      "Returns the Vault ID of the created object. If a custom header of type 'X-Force-Location' has a " +
-      "case-insensitive value of 'true', then the file path locations will be used as the location of the file object.")
+    notes = "Accepts a json packet as POST. Updates the Vault analysis object with the supplied output files. Returns the Vault ID of the created object." +
+      " If a custom header of type 'X-Force-Location' has a case-insensitive value of 'true', then the file path locations will be used as the location of the file object.")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "Analysis Vault ID"),
     new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.vault.model.AnalysisUpdate", paramType = "body", value = "Analysis outputs to add"),

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
@@ -21,9 +21,8 @@ trait UBamIngestService extends HttpService {
     produces = "application/json",
     consumes = "application/json",
     response = classOf[UBamIngestResponse],
-    notes = "Accepts a json packet as POST. Creates a Vault object with the supplied metadata and allocates BOSS objects for each supplied file key; ignores the values for each file. " +
-      " Returns the Vault ID of the object as well as presigned PUT urls - one for each key in the 'files' subobject. If a custom header of type 'X-Force-Location' has a case-insensitive " +
-      " value of 'true', then the file path locations will not be ignored and instead will be used as the location of the file object.")
+    notes = "Accepts a json packet as POST. Creates a Vault object with the supplied metadata and allocates BOSS objects for each supplied file key; ignores the values for each file. Returns the Vault ID of the object as well as" +
+      " presigned PUT urls - one for each key in the 'files' subobject. If a custom header of type 'X-Force-Location' has a case-insensitive value of 'true', then the file path locations will not be ignored and instead will be used as the location of the file object.")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.vault.model.UBamIngest", paramType = "body", value = "uBAM to create"),
     new ApiImplicitParam(name = "X-Force-Location", required = false, dataType = "boolean", paramType = "header", value = "When true, honors file path locations")


### PR DESCRIPTION
sbt publish seems to have problems with swagger documentation that spans 3 lines. IntelliJ showed no problem with this, but according to Ted Eclipse did show a problem. Reducing to two lines, even though that means we have awfully long lines.
