### PR TITLE
DSDEV-1876: Added 'properties' field to UBAM and Analysis objects

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/model/Analysis.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/model/Analysis.scala
@@ -6,9 +6,9 @@ import spray.json.DefaultJsonProtocol
 import scala.annotation.meta.field
 
 object AnalysisJsonProtocol extends DefaultJsonProtocol {
-  implicit val impAnalysisIngestResponse = jsonFormat1(AnalysisIngestResponse)
+  implicit val impAnalysisIngestResponse = jsonFormat2(AnalysisIngestResponse)
   implicit val impAnalysisIngest = jsonFormat2(AnalysisIngest)
-  implicit val impAnalysis = jsonFormat4(Analysis)
+  implicit val impAnalysis = jsonFormat5(Analysis)
   implicit val impAnalysisUpdate = jsonFormat1(AnalysisUpdate)
   implicit val impAnalysisDMUpdate = jsonFormat2(AnalysisDMUpdate)
 }
@@ -21,6 +21,8 @@ case class Analysis(
   input: List[String],
   @(ApiModelProperty@field)(required = true, value = "The metadata key-value pairs associated with this Analysis.")
   metadata: Map[String, String],
+  @(ApiModelProperty@field)(required = true, value = "The properties of this Analysis")
+  properties: Option[Map[String, String]] = None,
   @(ApiModelProperty@field)(required = true, value = "The output files associated with this Analysis, each with a unique user-supplied string key.")
   files: Option[Map[String, String]] = None)
 
@@ -32,14 +34,16 @@ case class AnalysisIngest(
 
 case class AnalysisIngestResponse(
   @(ApiModelProperty@field)(required = true, value = "The Vault ID of this Analysis")
-  id: String)
+  id: String,
+  @(ApiModelProperty@field)(required = true, value = "The properties of this Analysis")
+  properties: Option[Map[String, String]] = None)
 
 case class AnalysisUpdate(
   @(ApiModelProperty@field)(required = true, value = "The files associated with this Analysis, each with a unique user-supplied string key.")
   files: Map[String, String])
 
 case class AnalysisDMUpdate(
-   @(ApiModelProperty@field)(required = true, value = "The files associated with this Analysis, each with a unique user-supplied string key.")
-   files: Map[String, String],
-   @(ApiModelProperty@field)(required = true, value = "The metadata key-value pairs associated with this Analysis.")
-   metadata: Map[String, String])
+  @(ApiModelProperty@field)(required = true, value = "The files associated with this Analysis, each with a unique user-supplied string key.")
+  files: Map[String, String],
+  @(ApiModelProperty@field)(required = true, value = "The metadata key-value pairs associated with this Analysis.")
+  metadata: Map[String, String])

--- a/src/main/scala/org/broadinstitute/dsde/vault/model/Properties.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/model/Properties.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.vault.model
+
+object Properties {
+  val CreatedBy = "createdBy"
+  val CreatedDate = "createdDate"
+  val ModifiedBy = "modifiedBy"
+  val ModifiedDate = "modifiedDate"
+}

--- a/src/main/scala/org/broadinstitute/dsde/vault/model/UBam.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/model/UBam.scala
@@ -5,9 +5,9 @@ import spray.json.DefaultJsonProtocol
 import scala.annotation.meta.field
 
 object uBAMJsonProtocol extends DefaultJsonProtocol {
-  implicit val impUBam = jsonFormat3(UBam)
+  implicit val impUBam = jsonFormat4(UBam)
   implicit val impUBamIngest = jsonFormat2(UBamIngest)
-  implicit val impUBamIngestResponse = jsonFormat2(UBamIngestResponse)
+  implicit val impUBamIngestResponse = jsonFormat3(UBamIngestResponse)
 }
 
 @ApiModel(value = "An unmapped BAM")
@@ -17,7 +17,9 @@ case class UBam(
   @(ApiModelProperty @field)(required=true, value="The files associated with this uBAM, each with a unique user-supplied string key.")
   files: Map[String,String],
   @(ApiModelProperty @field)(required=true, value="The metadata key-value pairs associated with this uBAM.")
-  metadata: Map[String,String])
+  metadata: Map[String,String],
+  @(ApiModelProperty @field)(required=true, value = "The properties of this uBAM")
+  properties: Option[Map[String, String]] = None)
 
 case class UBamIngest(
   @(ApiModelProperty @field)(required=true, value="The files associated with this uBAM, each with a unique user-supplied string key.")
@@ -29,4 +31,6 @@ case class UBamIngestResponse(
   @(ApiModelProperty @field)(required=true, value="The Vault ID of this uBAM")
   id: String,
   @(ApiModelProperty @field)(required=true, value="The files associated with this uBAM, each with a unique user-supplied string key.")
-  files: Map[String,String])
+  files: Map[String,String],
+  @(ApiModelProperty @field)(required=true, value = "The properties of this uBAM")
+  properties: Option[Map[String, String]] = None)

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/DescribeServiceHandler.scala
@@ -37,7 +37,7 @@ case class DescribeServiceHandler(requestContext: RequestContext, version: Int, 
       val redirects = resolvedUBam.files.map {
         case (fileType, _) => (fileType, VaultConfig.Vault.ubamRedirectUrl(resolvedUBam.id, fileType))
       }
-      requestContext.complete(UBam(resolvedUBam.id, redirects, resolvedUBam.metadata).toJson.prettyPrint)
+      requestContext.complete(resolvedUBam.copy(files = redirects).toJson.prettyPrint)
       context.stop(self)
 
     case ClientFailure(message: String) =>

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.vault.services.analysis
 import org.broadinstitute.dsde.vault.model.{AnalysisIngest, AnalysisIngestResponse, UBamIngest, UBamIngestResponse}
 import org.broadinstitute.dsde.vault.services.uBAM.UBamIngestService
 import org.broadinstitute.dsde.vault.{VaultConfig, VaultFreeSpec}
+import org.broadinstitute.dsde.vault.model.Properties._
 import org.scalatest.{BeforeAndAfter, DoNotDiscover, Suite}
 import spray.http.StatusCodes._
 import spray.http.{ContentType, HttpEntity, MediaTypes}
@@ -64,6 +65,17 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
               val respAnalysis = responseAs[AnalysisIngestResponse]
               val createdId = java.util.UUID.fromString(respAnalysis.id)
               entity.toString should include(createdId.toString)
+
+              version match {
+                case Some(x) if x > 1 =>
+                  respAnalysis.properties shouldNot be(empty)
+                  respAnalysis.properties.get.get(CreatedBy) shouldNot be(empty)
+                  respAnalysis.properties.get.get(CreatedDate) shouldNot be(empty)
+                  respAnalysis.properties.get.get(ModifiedBy) should be(empty)
+                  respAnalysis.properties.get.get(ModifiedDate) should be(empty)
+                case _ =>
+                  respAnalysis.properties shouldBe empty
+              }
             }
           }
         }
@@ -82,6 +94,17 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
               val respAnalysis = responseAs[AnalysisIngestResponse]
               val createdId = java.util.UUID.fromString(respAnalysis.id)
               entity.toString should include(createdId.toString)
+
+              version match {
+                case Some(x) if x > 1 =>
+                  respAnalysis.properties shouldNot be(empty)
+                  respAnalysis.properties.get.get(CreatedBy) shouldNot be(empty)
+                  respAnalysis.properties.get.get(CreatedDate) shouldNot be(empty)
+                  respAnalysis.properties.get.get(ModifiedBy) should be(empty)
+                  respAnalysis.properties.get.get(ModifiedDate) should be(empty)
+                case _ =>
+                  respAnalysis.properties shouldBe empty
+              }
             }
           }
         }


### PR DESCRIPTION
Currently contains key-value pairs for created_by, created_date, modified_by, and modified_date fields from the database.

Note that this is co-dependent with changes to vault-datamanagement and apollo-api; merging this will break both until their changes are merged too.
