### PR TITLE
Refactor routes and directives

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultServiceActor.scala
@@ -36,9 +36,9 @@ class VaultServiceActor extends HttpServiceActor with ActorLogging {
   def receive = runRoute(
     swaggerService.routes ~ swaggerUiService ~
       logOpenAMRequest {
-        uBAMIngest.routes ~ uBAMDescribe.routes ~ uBAMRedirect.routes ~
-          analysisIngest.routes ~ analysisDescribe.routes ~ analysisUpdate.routes ~
-          analysisRedirect.routes ~ lookupService.routes
+        uBAMIngest.ubiRoute ~ uBAMDescribe.ubdRoute ~ uBAMRedirect.ubrRoute ~
+          analysisIngest.aiRoute ~ analysisDescribe.adRoute ~ analysisUpdate.auRoute ~ analysisRedirect.arRoute ~
+          lookupService.lRoute
       }
   )
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/VaultDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/VaultDirectives.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.vault.services
+
+import spray.http.MediaTypes._
+
+trait VaultDirectives extends spray.routing.Directives {
+  def respondWithJSON = respondWithMediaType(`application/json`)
+  def forceLocationHeader = optionalHeaderValueByName("X-Force-Location")
+}

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
@@ -4,11 +4,12 @@ import akka.actor.Props
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import spray.http.MediaTypes._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
-trait AnalysisDescribeService extends HttpService {
+trait AnalysisDescribeService extends HttpService with VaultDirectives {
 
   val adRoute = analysisDescribeRoute
 
@@ -28,16 +29,12 @@ trait AnalysisDescribeService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def analysisDescribeRoute = {
-    path("analyses" / Segment) {
-      id => {
-        get {
-          respondWithMediaType(`application/json`) {
-            requestContext => {
-              val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
-              val describeActor = actorRefFactory.actorOf(DescribeServiceHandler.props(requestContext, dmService))
-              describeActor ! DescribeServiceHandler.DescribeMessage(id)
-            }
-          }
+    path("analyses" / Segment) { id =>
+      get {
+        respondWithJSON { requestContext =>
+          val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
+          val describeActor = actorRefFactory.actorOf(DescribeServiceHandler.props(requestContext, dmService))
+          describeActor ! DescribeServiceHandler.DescribeMessage(id)
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeService.scala
@@ -10,7 +10,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
 trait AnalysisDescribeService extends HttpService {
 
-  val routes = analysisDescribeRoute
+  val adRoute = analysisDescribeRoute
 
   @ApiOperation(value = "Describes an Analysis' metadata, inputs, and output files.  Does not generate presigned URLs.",
     nickname = "analysis_describe",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
@@ -11,7 +11,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
 trait AnalysisIngestService extends HttpService {
 
-  val routes = analysisIngestRoute
+  val aiRoute = analysisIngestRoute
 
   @ApiOperation(
     value = "Creates Analysis objects",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestService.scala
@@ -4,12 +4,13 @@ import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
 import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import spray.http.MediaTypes._
 import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json")
-trait AnalysisIngestService extends HttpService {
+trait AnalysisIngestService extends HttpService with VaultDirectives {
 
   val aiRoute = analysisIngestRoute
 
@@ -35,13 +36,11 @@ trait AnalysisIngestService extends HttpService {
   def analysisIngestRoute =
     path("analyses") {
       post {
-        respondWithMediaType(`application/json`) {
-          entity(as[AnalysisIngest]) {
-            ingest =>
-              requestContext =>
-                val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
-                val ingestActor = actorRefFactory.actorOf(IngestServiceHandler.props(requestContext, dmService))
-                ingestActor ! IngestServiceHandler.IngestMessage(ingest)
+        respondWithJSON {
+          entity(as[AnalysisIngest]) { ingest => requestContext =>
+            val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
+            val ingestActor = actorRefFactory.actorOf(IngestServiceHandler.props(requestContext, dmService))
+            ingestActor ! IngestServiceHandler.IngestMessage(ingest)
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
@@ -23,15 +23,13 @@ trait AnalysisRedirectService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def analysisRedirectRoute =
-    path("analyses" / Segment / Segment) {
-      (id, filetype) =>
-        get {
-          requestContext =>
-            val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
-            val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
-            val redirectActor = actorRefFactory.actorOf(RedirectServiceHandler.props(requestContext, bossService, dmService))
-            redirectActor ! RedirectServiceHandler.RedirectMessage(id, filetype)
-        }
+    path("analyses" / Segment / Segment) { (id, filetype) =>
+      get { requestContext =>
+        val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+        val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
+        val redirectActor = actorRefFactory.actorOf(RedirectServiceHandler.props(requestContext, bossService, dmService))
+        redirectActor ! RedirectServiceHandler.RedirectMessage(id, filetype)
+      }
     }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectService.scala
@@ -7,7 +7,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 0)
 trait AnalysisRedirectService extends HttpService {
 
-  val routes = analysisRedirectRoute
+  val arRoute = analysisRedirectRoute
 
   @ApiOperation(value = "Redirects to presigned GET URLs for analyses", nickname = "analysis_redirect", httpMethod = "GET",
     notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified analysis output file. If the caller would like presigned URLs to all files within an analysis, " +

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
@@ -14,7 +14,7 @@ import spray.routing._
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 1)
 trait AnalysisUpdateService extends HttpService {
 
-  val routes = analysisUpdateRoute
+  val auRoute = analysisUpdateRoute
 
   @Path("/{id}/outputs")
   @ApiOperation(

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateService.scala
@@ -4,6 +4,7 @@ import javax.ws.rs.Path
 
 import akka.actor.Props
 import com.wordnik.swagger.annotations._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.impAnalysisUpdate
 import org.broadinstitute.dsde.vault.model._
@@ -12,7 +13,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 @Api(value = "/analyses", description = "Analysis Service", produces = "application/json", position = 1)
-trait AnalysisUpdateService extends HttpService {
+trait AnalysisUpdateService extends HttpService with VaultDirectives {
 
   val auRoute = analysisUpdateRoute
 
@@ -37,21 +38,15 @@ trait AnalysisUpdateService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def analysisUpdateRoute =
-    path("analyses" / Segment / "outputs") {
-      id => {
-        post {
-          optionalHeaderValueByName("X-Force-Location") {
-            forceLocation =>
-            respondWithMediaType(`application/json`) {
-              entity(as[AnalysisUpdate]) {
-                update =>
-                  requestContext => {
-                    val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
-                    val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
-                    val updateActor = actorRefFactory.actorOf(UpdateServiceHandler.props(requestContext, dmService, bossService))
-                    updateActor ! UpdateServiceHandler.UpdateMessage(id, update, forceLocation)
-                  }
-              }
+    path("analyses" / Segment / "outputs") { id =>
+      post {
+        forceLocationHeader { forceLocation =>
+          respondWithJSON {
+            entity(as[AnalysisUpdate]) { update => requestContext =>
+              val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+              val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
+              val updateActor = actorRefFactory.actorOf(UpdateServiceHandler.props(requestContext, dmService, bossService))
+              updateActor ! UpdateServiceHandler.UpdateMessage(id, update, forceLocation)
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
@@ -10,7 +10,7 @@ import spray.routing._
 @Api(value = "/query", description = "Lookup Service", produces = "application/json", position = 0)
 trait LookupService extends HttpService {
 
-  val routes = lookupRoute
+  val lRoute = lookupRoute
 
   @ApiOperation(value = "Queries entities by type and attribute key/value pair",
     nickname = "lookup",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
@@ -4,11 +4,12 @@ import akka.actor.Props
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import spray.http.MediaTypes._
 import spray.routing._
 
 @Api(value = "/query", description = "Lookup Service", produces = "application/json", position = 0)
-trait LookupService extends HttpService {
+trait LookupService extends HttpService with VaultDirectives {
 
   val lRoute = lookupRoute
 
@@ -29,17 +30,14 @@ trait LookupService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def lookupRoute = {
-    path("query" / Segment / Segment / Segment) {
-      (entityType, attributeName, attributeValue) =>
-        get {
-          respondWithMediaType(`application/json`) {
-            requestContext => {
-              val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
-              val describeActor = actorRefFactory.actorOf(LookupServiceHandler.props(requestContext, dmService))
-              describeActor ! LookupServiceHandler.LookupMessage(entityType, attributeName, attributeValue)
-            }
-          }
+    path("query" / Segment / Segment / Segment) { (entityType, attributeName, attributeValue) =>
+      get {
+        respondWithJSON { requestContext =>
+          val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
+          val describeActor = actorRefFactory.actorOf(LookupServiceHandler.props(requestContext, dmService))
+          describeActor ! LookupServiceHandler.LookupMessage(entityType, attributeName, attributeValue)
         }
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
@@ -2,13 +2,14 @@ package org.broadinstitute.dsde.vault.services.uBAM
 
 import akka.actor.Props
 import com.wordnik.swagger.annotations._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import spray.http.MediaTypes._
 import org.broadinstitute.dsde.vault.DmClientService
 import org.broadinstitute.dsde.vault.model._
 import spray.routing._
 
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
-trait UBamDescribeService extends HttpService {
+trait UBamDescribeService extends HttpService with VaultDirectives {
 
   val ubdRoute = uBamDescribeRoute
 
@@ -27,17 +28,14 @@ trait UBamDescribeService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def uBamDescribeRoute = {
-    path("ubams" / Segment) {
-      id =>
-        get {
-          respondWithMediaType(`application/json`) {
-            requestContext => {
-              val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
-              val describeActor = actorRefFactory.actorOf(DescribeServiceHandler.props(requestContext, dmService))
-              describeActor ! DescribeServiceHandler.DescribeMessage(id)
-            }
-          }
+    path("ubams" / Segment) { id =>
+      get {
+        respondWithJSON { requestContext =>
+          val dmService = actorRefFactory.actorOf(Props(new DmClientService(requestContext)))
+          val describeActor = actorRefFactory.actorOf(DescribeServiceHandler.props(requestContext, dmService))
+          describeActor ! DescribeServiceHandler.DescribeMessage(id)
         }
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeService.scala
@@ -10,7 +10,7 @@ import spray.routing._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamDescribeService extends HttpService {
 
-  val routes = uBamDescribeRoute
+  val ubdRoute = uBamDescribeRoute
 
   @ApiOperation(value = "Describes a uBAM's metadata and associated files.  Does not generate presigned URLs.",
     nickname = "ubam_describe",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
@@ -12,7 +12,7 @@ import uBAMJsonProtocol._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamIngestService extends HttpService {
 
-  val routes = uBamIngestRoute
+  val ubiRoute = uBamIngestRoute
 
   @ApiOperation(
     value = "Creates uBAM objects",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestService.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.vault.services.uBAM
 
 import com.wordnik.swagger.annotations._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
 import org.broadinstitute.dsde.vault.{BossClientService, DmClientService}
 import spray.http.MediaTypes._
 import spray.routing._
@@ -10,7 +11,7 @@ import spray.httpx.SprayJsonSupport._
 import uBAMJsonProtocol._
 
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
-trait UBamIngestService extends HttpService {
+trait UBamIngestService extends HttpService with VaultDirectives {
 
   val ubiRoute = uBamIngestRoute
 
@@ -35,23 +36,16 @@ trait UBamIngestService extends HttpService {
   def uBamIngestRoute =
     path("ubams") {
       post {
-        optionalHeaderValueByName("X-Force-Location") {
-          forceLocation =>
-          respondWithMediaType(`application/json`) {
-            entity(as[UBamIngest]) {
-              ingest =>
-                requestContext =>
-                  val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
-                  val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
-                  val ingestActor = actorRefFactory.actorOf(IngestServiceHandler.props(requestContext, bossService, dmService))
-                  ingestActor ! IngestServiceHandler.IngestMessage(ingest, forceLocation)
+        respondWithJSON {
+          forceLocationHeader { forceLocation =>
+            entity(as[UBamIngest]) { ingest => requestContext =>
+              val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+              val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
+              val ingestActor = actorRefFactory.actorOf(IngestServiceHandler.props(requestContext, bossService, dmService))
+              ingestActor ! IngestServiceHandler.IngestMessage(ingest, forceLocation)
             }
           }
         }
       }
     }
 }
-
-
-
-

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
@@ -23,15 +23,13 @@ trait UBamRedirectService extends HttpService {
     new ApiResponse(code = 500, message = "Vault Internal Error")
   ))
   def uBamRedirectRoute =
-    path("ubams" / Segment / Segment) {
-      (id, filetype) =>
-        get {
-          requestContext =>
-            val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
-            val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
-            val redirectActor = actorRefFactory.actorOf(RedirectServiceHandler.props(requestContext, bossService, dmService))
-            redirectActor ! RedirectServiceHandler.RedirectMessage(id, filetype)
-        }
+    path("ubams" / Segment / Segment) { (id, filetype) =>
+      get { requestContext =>
+        val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+        val dmService = actorRefFactory.actorOf(DmClientService.props(requestContext))
+        val redirectActor = actorRefFactory.actorOf(RedirectServiceHandler.props(requestContext, bossService, dmService))
+        redirectActor ! RedirectServiceHandler.RedirectMessage(id, filetype)
+      }
     }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectService.scala
@@ -7,7 +7,7 @@ import spray.routing._
 @Api(value = "/ubams", description = "uBAM Service", produces = "application/json", position = 0)
 trait UBamRedirectService extends HttpService {
 
-  val routes = uBamRedirectRoute
+  val ubrRoute = uBamRedirectRoute
 
   @ApiOperation(value = "Redirects to presigned GET URLs for uBAM files", nickname = "ubam_redirect", httpMethod = "GET",
     notes = "Returns an HTTP 307 redirect to a presigned GET URL for the specified uBAM file. If the caller would like presigned URLs to all files within an object, " +

--- a/src/test/scala/org/broadinstitute/dsde/vault/VaultFreeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/VaultFreeSpec.scala
@@ -8,6 +8,8 @@ import akka.pattern.ask
 import org.broadinstitute.dsde.vault.OpenAmClientService.{OpenAmResponse, OpenAmAuthRequest}
 import org.scalatest._
 import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher}
+import spray.http.HttpCookie
+import spray.http.HttpHeaders.Cookie
 import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.Await
@@ -25,6 +27,12 @@ abstract class VaultFreeSpec extends FreeSpec with Matchers with VaultCustomMatc
     val future = actor ? OpenAmAuthRequest(VaultConfig.OpenAm.testUser, VaultConfig.OpenAm.testUserPassword)
     Some(Await.result(future, duration).asInstanceOf[OpenAmResponse])
   }
+
+  lazy val openAmResponse = getOpenAmToken.get
+  def addOpenAmCookie: RequestTransformer = {
+    Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId))
+  }
+
 }
 
 // enables tests for "should be a UUID" etc

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
@@ -11,8 +11,6 @@ import spray.httpx.unmarshalling._
 
 class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeService with AnalysisUpdateService with AnalysisIngestService {
 
-  override val routes = analysisDescribeRoute
-
   def actorRefFactory = system
 
   val openAmResponse = getOpenAmToken.get

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisDescribeServiceSpec.scala
@@ -13,7 +13,6 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
   def actorRefFactory = system
 
-  val openAmResponse = getOpenAmToken.get
   var testId = "invalid_UUID"
 
   "AnalysisDescribeServiceSpec" - {
@@ -23,7 +22,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
           input = List(),
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> analysisIngestRoute ~> check {
           status should equal(OK)
           val respAnalysis = responseAs[AnalysisIngestResponse]
           testId = respAnalysis.id
@@ -33,7 +32,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the Analysis Describe path with a Vault ID" - {
       "should return that ID" in {
-        Get(VaultConfig.Vault.analysisDescribePath(testId)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisDescribeRoute ~> check {
+        Get(VaultConfig.Vault.analysisDescribePath(testId)) ~> addOpenAmCookie ~> analysisDescribeRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include(testId)
@@ -52,7 +51,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
     "when calling POST to the Analysis Update path in order to add completed files" - {
       "should return as OK" in {
         val analysisUpdate = new AnalysisUpdate(files = Map("vcf" -> "vault/test/test.vcf", "bai" -> "vault/test/test.bai", "bam" -> "vault/test/test.bam"))
-        Post(VaultConfig.Vault.analysisUpdatePath(testId), analysisUpdate) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisUpdateRoute ~> check {
+        Post(VaultConfig.Vault.analysisUpdatePath(testId), analysisUpdate) ~> addOpenAmCookie ~> analysisUpdateRoute ~> check {
           status should equal(OK)
           val analysisResponse = responseAs[Analysis]
           val files = responseAs[Analysis].files
@@ -66,7 +65,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the Analysis Describe path with a Vault ID" - {
       "should reference the new files" in {
-        Get(VaultConfig.Vault.analysisDescribePath(testId)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisDescribeRoute ~> check {
+        Get(VaultConfig.Vault.analysisDescribePath(testId)) ~> addOpenAmCookie ~> analysisDescribeRoute ~> check {
           status should equal(OK)
           val respAnalysis = responseAs[Analysis]
           respAnalysis.id should equal(testId)
@@ -83,7 +82,7 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
 
     "when calling GET to the Analysis Describe path with an invalid Vault ID" - {
       "should return a Not Found error" in {
-        Get(VaultConfig.Vault.analysisDescribePath("unknown-not-found-id")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisDescribeRoute) ~> check {
+        Get(VaultConfig.Vault.analysisDescribePath("unknown-not-found-id")) ~> addOpenAmCookie ~> sealRoute(analysisDescribeRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -107,6 +106,5 @@ class AnalysisDescribeServiceSpec extends VaultFreeSpec with AnalysisDescribeSer
       }
     }
   }
-
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -15,8 +15,6 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
   import spray.httpx.SprayJsonSupport._
   def actorRefFactory = system
 
-  val openAmResponse = getOpenAmToken.get
-
   var createdUBams: Seq[String] = Seq("bad", "ids")
 
   override def beforeAll(): Unit = {
@@ -29,7 +27,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
     // create a few ubams
     createdUBams = (for (x <- 1 to 3) yield
 
-      Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+      Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
         status should equal(OK)
         responseAs[UBamIngestResponse].id
       }
@@ -48,7 +46,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = List(),
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> analysisIngestRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include("id")
@@ -66,7 +64,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = List(createdUBams.head),
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> analysisIngestRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include("id")
@@ -84,7 +82,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = List(createdUBams.head) :+ "intentionallyBadForeignKey",
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisIngestRoute) ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -96,7 +94,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = createdUBams.toList,
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> analysisIngestRoute ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> analysisIngestRoute ~> check {
           status should equal(OK)
           // test response as raw string
           entity.toString should include("id")
@@ -114,7 +112,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
           input = createdUBams.toList :+ "intentionallyBadForeignKey",
           metadata = Map("testAttr" -> "testValue", "randomData" -> "7")
         )
-        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisIngestRoute) ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, analysisIngest) ~> addOpenAmCookie ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -123,7 +121,7 @@ class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService
     "when calling POST to the Analysis Ingest path with an invalid object" - {
       "should return a Bad Request error" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(VaultConfig.Vault.analysisIngestPath, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(analysisIngestRoute) ~> check {
+        Post(VaultConfig.Vault.analysisIngestPath, malformedEntity) ~> addOpenAmCookie ~> sealRoute(analysisIngestRoute) ~> check {
           status should equal(BadRequest)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisIngestServiceSpec.scala
@@ -10,8 +10,6 @@ import spray.http.{ContentType, HttpCookie, HttpEntity, MediaTypes}
 
 class AnalysisIngestServiceSpec extends VaultFreeSpec with AnalysisIngestService with UBamIngestService with BeforeAndAfterAll {
 
-  override val routes = analysisIngestRoute
-
   import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol.{impAnalysisIngest, impAnalysisIngestResponse}
   import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol.{impUBamIngest, impUBamIngestResponse}
   import spray.httpx.SprayJsonSupport._

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisRedirectServiceSpec.scala
@@ -10,8 +10,6 @@ import spray.httpx.SprayJsonSupport._
 
 class AnalysisRedirectServiceSpec extends VaultFreeSpec with AnalysisRedirectService with AnalysisIngestService with AnalysisUpdateService {
 
-  override val routes = analysisRedirectRoute
-
   def actorRefFactory = system
   val openAmResponse = getOpenAmToken.get
   var testingId = "invalid_UUID"

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/analysis/AnalysisUpdateServiceSpec.scala
@@ -12,8 +12,6 @@ import spray.httpx.SprayJsonSupport._
 
 class AnalysisUpdateServiceSpec extends VaultFreeSpec with AnalysisUpdateService with UBamIngestService {
 
-  override val routes = analysisUpdateRoute
-
   def actorRefFactory = system
 
   val openAmResponse = getOpenAmToken.get

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
@@ -12,8 +12,6 @@ import spray.httpx.SprayJsonSupport._
 
 class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngestService {
 
-  override val routes = lookupRoute
-
   def actorRefFactory = system
 
   val openAmResponse = getOpenAmToken.get

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceSpec.scala
@@ -14,8 +14,6 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
 
   def actorRefFactory = system
 
-  val openAmResponse = getOpenAmToken.get
-
   var testDataGuid: String = "not-a-uuid"
   val testValue = java.util.UUID.randomUUID().toString
 
@@ -25,7 +23,7 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
         val files = Map(("bam", "vault/test/test.bam"), ("bai", "vault/test/test.bai"))
         val metadata = Map("testAttr" -> "testValue", "uniqueTest" -> testValue)
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testDataGuid = responseAs[UBamIngestResponse].id
         }
@@ -34,7 +32,7 @@ class LookupServiceSpec extends VaultFreeSpec with LookupService with UBamIngest
 
     "when accessing the Lookup path" - {
       "Lookup should return previously stored unmapped BAM" in {
-            Get(VaultConfig.Vault.lookupPath("ubam", "uniqueTest", testValue)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~>  lookupRoute ~> check {
+            Get(VaultConfig.Vault.lookupPath("ubam", "uniqueTest", testValue)) ~> addOpenAmCookie ~>  lookupRoute ~> check {
               val entitySearchResult = responseAs[EntitySearchResult]
               entitySearchResult.guid should be(testDataGuid)
                entitySearchResult.`type` should be("ubam")

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeServiceSpec.scala
@@ -11,7 +11,6 @@ import spray.httpx.SprayJsonSupport._
 class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UBamIngestService {
 
   def actorRefFactory = system
-  val openAmResponse = getOpenAmToken.get
   var testingId = "invalid_UUID"
 
   val files = Map(("bam", "vault/test/test.bam"), ("bai", "vault/test/test.bai"))
@@ -21,7 +20,7 @@ class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService wit
     "while preparing the ubam test data" - {
       "should successfully store the data using the UBam Ingest path" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[UBamIngestResponse].id
         }
@@ -30,7 +29,7 @@ class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService wit
 
     "when calling GET to the UBam Describe path with a Vault ID" - {
       "should return that ID" in {
-        Get(VaultConfig.Vault.ubamDescribePath(testingId)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamDescribeRoute ~> check {
+        Get(VaultConfig.Vault.ubamDescribePath(testingId)) ~> addOpenAmCookie ~> uBamDescribeRoute ~> check {
           status should equal(OK)
           val response = responseAs[UBam]
           response.id should be(testingId)
@@ -45,7 +44,7 @@ class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService wit
 
     "when calling GET to the UBam Describe path with an unknown Vault ID" - {
       "should return a 404 not found error" in {
-        Get(VaultConfig.Vault.ubamDescribePath("12345-67890-12345")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
+        Get(VaultConfig.Vault.ubamDescribePath("12345-67890-12345")) ~> addOpenAmCookie ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -53,7 +52,7 @@ class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService wit
 
     "when calling PUT to the UBam Describe path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(VaultConfig.Vault.ubamDescribePath(testingId)) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
+        Put(VaultConfig.Vault.ubamDescribePath(testingId)) ~> addOpenAmCookie ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -62,7 +61,7 @@ class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService wit
 
     "when calling POST to the UBam Describe path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(VaultConfig.Vault.ubamDescribePath("arbitrary_id")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamDescribeRoute) ~> check {
+        Post(VaultConfig.Vault.ubamDescribePath("arbitrary_id")) ~> addOpenAmCookie ~> sealRoute(uBamDescribeRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamDescribeServiceSpec.scala
@@ -10,8 +10,6 @@ import spray.httpx.SprayJsonSupport._
 
 class UBamDescribeServiceSpec extends VaultFreeSpec with UBamDescribeService with UBamIngestService {
 
-  override val routes = uBamDescribeRoute
-
   def actorRefFactory = system
   val openAmResponse = getOpenAmToken.get
   var testingId = "invalid_UUID"

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamIngestServiceSpec.scala
@@ -11,7 +11,6 @@ import spray.httpx.SprayJsonSupport._
 class UBamIngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
   def actorRefFactory = system
-  val openAmResponse = getOpenAmToken.get
 
   "UBamIngestServiceSpec" - {
 
@@ -23,7 +22,7 @@ class UBamIngestServiceSpec extends VaultFreeSpec with UBamIngestService {
     "when calling POST to the UBam Ingest path with a UBamIngest object" - {
       "should return a valid response" in {
         // As designed, the API returns an object that only contains an id and files, but not the supplied metadata
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           responseAs[String] should include("bam")
           responseAs[String] should include("bai")
@@ -35,7 +34,7 @@ class UBamIngestServiceSpec extends VaultFreeSpec with UBamIngestService {
 
     "when calling POST to the UBam Ingest path with a UBamIngest object and 'X-Force-Location' header" - {
       "should return a valid response with the provided file paths" in {
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           val files = responseAs[UBamIngestResponse].files
           files.get("bam").get should equal("vault/test/test.bam")
@@ -65,7 +64,7 @@ class UBamIngestServiceSpec extends VaultFreeSpec with UBamIngestService {
     "when calling POST to the UBam Ingest path with a malformed UBamIngest object" - {
       "should return an invalid response" in {
         val malformedEntity = HttpEntity(ContentType(MediaTypes.`application/json`), """{"random":"data"}""")
-        Post(VaultConfig.Vault.ubamIngestPath, malformedEntity) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamIngestRoute) ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, malformedEntity) ~> addOpenAmCookie ~> sealRoute(uBamIngestRoute) ~> check {
           status should equal(BadRequest)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectServiceSpec.scala
@@ -10,8 +10,6 @@ import spray.httpx.SprayJsonSupport._
 
 class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UBamIngestService {
 
-  override val routes = uBamRedirectRoute
-
   def actorRefFactory = system
   val openAmResponse = getOpenAmToken.get
   var testingId = "invalid_UUID"

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/uBAM/UBamRedirectServiceSpec.scala
@@ -11,7 +11,6 @@ import spray.httpx.SprayJsonSupport._
 class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService with UBamIngestService {
 
   def actorRefFactory = system
-  val openAmResponse = getOpenAmToken.get
   var testingId = "invalid_UUID"
   var forceTestingId = "invalid_UUID"
 
@@ -22,7 +21,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
     "while preparing the ubam test data" - {
       "should successfully store the data using the UBam Ingest path" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           testingId = responseAs[UBamIngestResponse].id
         }
@@ -31,7 +30,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "when calling GET to the UBam Redirect path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamRedirectRoute ~> check {
+        Get(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> addOpenAmCookie ~> uBamRedirectRoute ~> check {
           status should equal(TemporaryRedirect)
         }
       }
@@ -39,7 +38,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "when calling GET to the UBam Redirect path with a valid Vault ID and an invalid file type" - {
       "should return a Bad Request response" in {
-        Get(VaultConfig.Vault.ubamRedirectPath(testingId, "invalid")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
+        Get(VaultConfig.Vault.ubamRedirectPath(testingId, "invalid")) ~> addOpenAmCookie ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(BadRequest)
         }
       }
@@ -47,7 +46,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "when calling GET to the UBam Redirect path with an invalid Vault ID and a valid file type" - {
       "should return a a Not Found response" in {
-        Get(VaultConfig.Vault.ubamRedirectPath("12345-67890-12345", "bai")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
+        Get(VaultConfig.Vault.ubamRedirectPath("12345-67890-12345", "bai")) ~> addOpenAmCookie ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(NotFound)
         }
       }
@@ -55,7 +54,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "when calling PUT to the UBam Redirect path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Put(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
+        Put(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> addOpenAmCookie ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -64,7 +63,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "when calling POST to the UBam Redirect path with a Vault ID" - {
       "should return a MethodNotAllowed error" in {
-        Post(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> sealRoute(uBamRedirectRoute) ~> check {
+        Post(VaultConfig.Vault.ubamRedirectPath(testingId, "bai")) ~> addOpenAmCookie ~> sealRoute(uBamRedirectRoute) ~> check {
           status should equal(MethodNotAllowed)
           entity.toString should include("HTTP method not allowed, supported methods: GET")
         }
@@ -74,7 +73,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
     "X-Force-Location API: while preparing the ubam test data" - {
       "should successfully store the data using the UBam Ingest path" in {
         val ubamIngest = new UBamIngest(files, metadata)
-        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamIngestRoute ~> check {
+        Post(VaultConfig.Vault.ubamIngestPath, ubamIngest) ~> addHeader("X-Force-Location", "true") ~> addOpenAmCookie ~> uBamIngestRoute ~> check {
           status should equal(OK)
           forceTestingId = responseAs[UBamIngestResponse].id
           files.get("bam").get should equal("vault/test/test.bam")
@@ -86,7 +85,7 @@ class UBamRedirectServiceSpec extends VaultFreeSpec with UBamRedirectService wit
 
     "X-Force-Location API: when calling GET to the UBam Redirect path with a valid Vault ID and a valid file type" - {
       "should return a redirect url to the file" in {
-        Get(VaultConfig.Vault.ubamRedirectPath(forceTestingId, "bai")) ~> Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId)) ~> uBamRedirectRoute ~> check {
+        Get(VaultConfig.Vault.ubamRedirectPath(forceTestingId, "bai")) ~> addOpenAmCookie ~> uBamRedirectRoute ~> check {
           status should equal(TemporaryRedirect)
           // test that the redirect properly handles the file path we passed in, which includes slashes
           // this test will fail if Google changes how they sign urls


### PR DESCRIPTION
DSDEV-1945
DSDEV-1947

I made an additional formatting change not included in those stories: moving routing extractions to the same line as the directive that extracted them.  I think this makes it more clear where the extracted value comes from.  As an example, the new `forceLocationHeader` extracts `forceLocation`:

```
forceLocationHeader { forceLocation =>
```
