### PR TITLE
DSDEV-2019: Rehome the Lookup Service ('query') on top of DM's generic API.

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -48,7 +48,6 @@ dm {
   analysesUpdatePath="/analyses/%s/outputs"
   ubamCollectionsPath="/ubamcollections/v%s"
   uBamCollectionsResolvePath="/ubamcollections/v%s/%s"
-  queryLookupPath="/query/%s/%s/%s"
 
   genericIngestPath="/entities/v%s"
   genericDescribePath="/entities/v%s/%s"

--- a/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
@@ -7,6 +7,7 @@ import akka.event.Logging
 import akka.util.Timeout
 import org.broadinstitute.dsde.vault.DmClientService._
 import org.broadinstitute.dsde.vault.model.AnalysisJsonProtocol._
+import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
 import org.broadinstitute.dsde.vault.model.LookupJsonProtocol._
 import org.broadinstitute.dsde.vault.model.uBAMCollectionJsonProtocol._
 import org.broadinstitute.dsde.vault.model.uBAMJsonProtocol._
@@ -35,7 +36,7 @@ object DmClientService {
   case class DMUpdateAnalysis(analysisId: String, update: AnalysisUpdate)
   case class DMAnalysisUpdated(analysis: Analysis)
 
-  case class DMLookupEntity(entityType: String, attributeName: String, attributeValue: String)
+  case class DMLookupEntity(entityType: String, attributeName: String, attributeValue: String, version: Int)
   case class DMLookupResolved(result: EntitySearchResult)
   case class DMCreateUBamCollection(ubamCollectionIngest: UBamCollectionIngest, version: Int)
   case class DMUBamCollectionCreated(uBAMCollection: UBamCollection)
@@ -80,8 +81,8 @@ case class DmClientService(requestContext: RequestContext) extends Actor{
     case DMUpdateAnalysis(analysisId, update) =>
       updateAnalysis(sender(), analysisId, update)
 
-    case DMLookupEntity(entityType, attributeName, attributeValue) =>
-      lookup(sender(), entityType, attributeName, attributeValue)
+    case DMLookupEntity(entityType, attributeName, attributeValue, version) =>
+      lookup(sender(), entityType, attributeName, attributeValue, version)
   }
 
   def createUBam(senderRef: ActorRef, ubam: UBamIngest): Unit = {
@@ -224,20 +225,58 @@ case class DmClientService(requestContext: RequestContext) extends Actor{
     }
   }
 
-  def lookup(senderRef: ActorRef, entityType: String, attributeName: String, attributeValue: String): Unit = {
+  def lookup(senderRef: ActorRef, entityType: String, attributeName: String, attributeValue: String, version: Int): Unit = {
     log.debug("Querying the DM API for a lookup on %s/%s/%s. ".format(entityType, attributeName, attributeValue))
-    val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive ~> unmarshal[EntitySearchResult]
+
+    /*
+      The old Lookup Service in DM performed a mapping between the physical entity type we store in the DB (e.g.
+      "unmappedBAM") and the endpoint name (e.g. "ubam"). The new generic service does not perform this mapping,
+      and I don't think we want the mapping. For backwards compatibility, we therefore need to perform the
+      translation here, inside this deprecated API, and leave the new DM generic service alone.
+     */
+    val legacyMappedEntityType = EntityType.TYPES.find(_.endpoint == entityType) match {
+      case Some(endpointType) => endpointType.databaseKey
+      case None => entityType
+    }
+
+    val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive ~> unmarshal[List[GenericEntity]]
     val responseFuture = pipeline {
-      Get(VaultConfig.DataManagement.queryLookupUrl(entityType, attributeName, attributeValue))
+
+      val spec = GenericAttributeSpec(attributeName, attributeValue)
+      val entityQuery = GenericEntityQuery(legacyMappedEntityType, Seq(spec), false)
+
+      Post(VaultConfig.DataManagement.queryLookupUrl(version), entityQuery)
     }
     responseFuture onComplete {
       case Success(queryResult) =>
-        log.debug("Found entity matching %s/%s/%s: ID %s".format(entityType, attributeName, attributeValue, queryResult.guid))
-        senderRef ! DMLookupResolved(queryResult)
-
+        // reshape/parse response for compatibility
+        val firstResultEntity = queryResult.headOption match {
+          case Some(ent) => {
+            // I don't like that this uses the type passed in by the user instead of the type from the result.
+            // But, that's the way DM worked, and this API is deprecated, so it's not worth changing
+            val result = EntitySearchResult(ent.guid, entityType)
+            log.debug("Found entity matching %s/%s/%s: ID %s".format(entityType, attributeName, attributeValue, ent.guid))
+            senderRef ! DMLookupResolved(result)
+          }
+          case None => {
+            // query succeeded, but no results found
+            val msg = "No entities found for %s/%s/%s".format(entityType, attributeName, attributeValue)
+            log.debug(msg)
+            senderRef ! ClientFailure(msg)
+          }
+        }
       case Failure(error) =>
-        log.error(error, "Couldn't find entity matching %s/%s/%s".format(entityType, attributeName, attributeValue))
+        log.error(error, "Failure finding entity matching %s/%s/%s".format(entityType, attributeName, attributeValue))
         senderRef ! ClientFailure(error.getMessage)
     }
   }
+}
+
+case class EntityType(databaseKey: String, endpoint: String)
+
+object EntityType {
+  val UNMAPPED_BAM = EntityType("unmappedBAM", "ubam")
+  val ANALYSIS = EntityType("analysis", "analyses")
+  val UBAM_COLLECTION = EntityType("uBAMCollection", "ubamcollection")
+  val TYPES = Seq(UNMAPPED_BAM, ANALYSIS, UBAM_COLLECTION)
 }

--- a/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/DmClientService.scala
@@ -245,7 +245,7 @@ case class DmClientService(requestContext: RequestContext) extends Actor{
       val spec = GenericAttributeSpec(attributeName, attributeValue)
       val entityQuery = GenericEntityQuery(legacyMappedEntityType, Seq(spec), false)
 
-      Post(VaultConfig.DataManagement.queryLookupUrl(version), entityQuery)
+      Post(VaultConfig.DataManagement.genericSearchUrl(version), entityQuery)
     }
     responseFuture onComplete {
       case Success(queryResult) =>

--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
@@ -118,7 +118,7 @@ object VaultConfig {
 
     def genericSearchPath(version: Int) = dm.getString("genericSearchPath").format(version)
     def genericSearchUrl(version: Int) = server + genericSearchPath(version)
-  }
+}
 
   object BOSS {
     private val boss = config.getConfig("boss")

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupService.scala
@@ -17,6 +17,7 @@ trait LookupService extends HttpService with VaultDirectives {
 
   val lRoute = lookupRoute
 
+  @Deprecated
   @ApiOperation(value = "Queries entities by type and attribute key/value pair",
     nickname = "lookup",
     httpMethod = "GET",

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/lookup/LookupServiceHandler.scala
@@ -26,7 +26,7 @@ case class LookupServiceHandler(requestContext: RequestContext, version: Int, dm
   def receive = {
     case LookupMessage(entityType, attributeName, attributeValue) =>
       log.debug("Received lookup message")
-      dmService ! DmClientService.DMLookupEntity(entityType, attributeName, attributeValue)
+      dmService ! DmClientService.DMLookupEntity(entityType, attributeName, attributeValue, version)
 
     case DMLookupResolved(result: EntitySearchResult) =>
       requestContext.complete(result.toJson.prettyPrint)

--- a/src/test/resources/testing.conf
+++ b/src/test/resources/testing.conf
@@ -43,7 +43,7 @@ dm {
   analysesUpdatePath="/analyses/%s/outputs"
   ubamCollectionsPath="/ubamcollections/v%s"
   uBamCollectionsResolvePath="/ubamcollections/v%s/%s"
-  queryLookupPath="/query/%s/%s/%s"
+  queryLookupPath="/entities/v%s/search"
 }
 
 boss {

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/mock/Servers.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/mock/Servers.scala
@@ -35,16 +35,30 @@ object Servers{
 
   def startUpDM(): Unit = {
 
+    /* ----------------- Generic API ----------------------*/
+
+    val lookupResponse = new EntitySearchResult(
+      "testing_id",
+      "ubam"
+    )
+
+    Servers.mockDMServer.when(
+      request()
+        .withMethod("GET")
+        .withPath("/entities/search/ubam")
+    ).respond(
+        response()
+          .withHeader(header)
+          .withBody(lookupResponse.toJson.prettyPrint)
+          .withStatusCode(200)
+      )
+
+
     /* ----------------- UBams ----------------------*/
     val ubam = new UBam(
       "testing_id",
       Map(("bam", "http://localhost:8080/path/to/bam"), ("bai", "pathToBai")),
       Map("testAttr" -> "testValue")
-    )
-
-    val lookupResponse = new EntitySearchResult(
-      "testing_id",
-      "ubam"
     )
 
     Servers.mockDMServer
@@ -109,17 +123,6 @@ object Servers{
         response()
           .withBody("HTTP method not allowed, supported methods: GET")
           .withStatusCode(405)
-      )
-
-    Servers.mockDMServer.when(
-      request()
-        .withMethod("GET")
-        .withPath("/query/ubam/uniqueTest/.*")
-    ).respond(
-        response()
-          .withHeader(header)
-          .withBody(lookupResponse.toJson.prettyPrint)
-          .withStatusCode(200)
       )
 
     /* ----------- UBam Collections ----------------- */


### PR DESCRIPTION
DO NOT MERGE.

This PR is close but not quite complete. I'm pushing it out now to give @MattPutnam some framework on similar stories.

Obstacles:
1) will require coordinated changes in cmi-chef-repo and Jenkins for config files. I haven't done the chef changes yet, even though they're simple.
2) all tests pass against DM. However, I still get 2 test failures when running with testing.conf in mock-server mode. These are the 2 test failures that Veronica, Anabella, and Greg could not reproduce ... but I still can't claim I'm seeing 100% passing.

This change rehomes the vault-api lookup service on top of the DM generic api, and marks the lookup service as deprecated. I had a little hoop to jump through regarding "unmappedBAM" vs. "ubam", as you can see in the code. This is ugly code, but since it's limited to a deprecated api I feel okay about it.
