### PR TITLE
Generic Ingest

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -30,6 +30,12 @@ vault {
   ubamsRedirectPath="/ubams/%s/%s"
   ubamCollectionsIngestPath="/ubamcollections/v%s"
   ubamCollectionsDescribePath="/ubamcollections/v%s/%s"
+
+  genericIngestPath="/entities/v%s"
+  genericDescribePath="/entities/v%s/%s"
+  genericDescribeUpPath="/entities/v%s/%s?up"
+  genericDescribeDownPath="/entities/v%s/%s?down"
+  genericSearchPath="/entities/v%s/search"
 }
 
 
@@ -43,6 +49,12 @@ dm {
   ubamCollectionsPath="/ubamcollections/v%s"
   uBamCollectionsResolvePath="/ubamcollections/v%s/%s"
   queryLookupPath="/query/%s/%s/%s"
+
+  genericIngestPath="/entities/v%s"
+  genericDescribePath="/entities/v%s/%s"
+  genericDescribeUpPath="/entities/v%s/%s?up"
+  genericDescribeDownPath="/entities/v%s/%s?down"
+  genericSearchPath="/entities/v%s/search"
 }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/vault/GenericDmClientService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/GenericDmClientService.scala
@@ -1,0 +1,79 @@
+package org.broadinstitute.dsde.vault
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.event.Logging
+import akka.util.Timeout
+import org.broadinstitute.dsde.vault.GenericDmClientService._
+import org.broadinstitute.dsde.vault.model.{GenericIngest, GenericEntity}
+import org.broadinstitute.dsde.vault.services.ClientFailure
+import spray.client.pipelining._
+import spray.http.HttpHeaders.Cookie
+import spray.routing.RequestContext
+import spray.httpx.SprayJsonSupport._
+import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
+
+import scala.util.{Failure, Success}
+
+object GenericDmClientService {
+  case class DMGenericIngest(ingest: GenericIngest, version: Int)
+  case class DMGenericIngestResponse(guids: List[String])
+
+  case class DMGenericDescribe(guid: String, version: Int, describeKey: Int)
+  case class DMGenericDescribeResponse(entity: GenericEntity, describeKey: Int)
+
+  def props(requestContext: RequestContext): Props = Props(new GenericDmClientService(requestContext))
+}
+
+case class GenericDmClientService(requestContext: RequestContext) extends Actor{
+
+  import system.dispatcher
+
+  implicit val timeout = Timeout(5, TimeUnit.SECONDS)
+  implicit val system = context.system
+  val log = Logging(system, getClass)
+
+  override def receive: Receive = {
+    case DMGenericIngest(ingest, version) =>
+      genericIngest(sender(), ingest, version)
+
+    case DMGenericDescribe(guid, version, key) =>
+      genericDescribe(sender(), guid, version, key)
+  }
+
+ def genericIngest(senderRef: ActorRef, ingest: GenericIngest, version: Int): Unit = {
+   log.debug("DM Generic Ingest")
+   val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive ~> unmarshal[List[String]]
+   val responseFuture = pipeline {
+     Post(VaultConfig.DataManagement.genericIngestUrl(version), ingest)
+   }
+   responseFuture onComplete {
+     case Success(guids) =>
+       log.debug("DM Generic Ingest successful")
+       senderRef ! DMGenericIngestResponse(guids)
+
+     case Failure(error) =>
+       log.error(error, "DM Generic Ingest Failure")
+       senderRef ! ClientFailure(error.getMessage)
+   }
+ }
+
+  def genericDescribe(senderRef: ActorRef, guid: String, version: Int, describeKey: Int): Unit = {
+    log.debug("DM Generic Describe for " + guid)
+    val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive ~> unmarshal[GenericEntity]
+    val responseFuture = pipeline {
+      Get(VaultConfig.DataManagement.genericDescribeUrl(version, guid))
+    }
+    responseFuture onComplete {
+      case Success(entity) =>
+        log.debug("DM Generic Describe for %s Successful".format(guid))
+        senderRef ! DMGenericDescribeResponse(entity, describeKey)
+
+      case Failure(error) =>
+        log.error(error, "DM Generic Describe for %s Failed".format(guid))
+        senderRef ! ClientFailure(error.getMessage)
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/VaultConfig.scala
@@ -61,6 +61,20 @@ object VaultConfig {
     def ubamCollectionIngestPath(version: Int) = vault.getString("ubamCollectionsIngestPath").format(version)
     def ubamCollectionIngestUrl(version: Int) = server + ubamIngestPath(version)
 
+    def genericIngestPath(version: Int) = vault.getString("genericIngestPath").format(version)
+    def genericIngestUrl(version: Int) = server + genericIngestPath(version)
+
+    def genericDescribePath(version: Int, id: String) = vault.getString("genericDescribePath").format(version, id)
+    def genericDescribeUrl(version: Int, id: String) = server + genericDescribePath(version, id)
+
+    def genericDescribeUpPath(version: Int, id: String) = vault.getString("genericDescribeUpPath").format(version, id)
+    def genericDescribeUpUrl(version: Int, id: String) = server + genericDescribeUpPath(version, id)
+
+    def genericDescribeDownPath(version: Int, id: String) = vault.getString("genericDescribeDownPath").format(version, id)
+    def genericDescribeDownUrl(version: Int, id: String) = server + genericDescribeDownPath(version, id)
+
+    def genericSearchPath(version: Int) = vault.getString("genericSearchPath").format(version)
+    def genericSearchUrl(version: Int) = server + genericSearchPath(version)
   }
 
   object DataManagement {
@@ -89,6 +103,21 @@ object VaultConfig {
 
     def queryLookupPath(entityType: String, attributeName: String, attributeValue: String) = dm.getString("queryLookupPath").format(entityType, attributeName, attributeValue)
     def queryLookupUrl(entityType: String, attributeName: String, attributeValue: String) = server + queryLookupPath(entityType, attributeName, attributeValue)
+
+    def genericIngestPath(version: Int) = dm.getString("genericIngestPath").format(version)
+    def genericIngestUrl(version: Int) = server + genericIngestPath(version)
+
+    def genericDescribePath(version: Int, id: String) = dm.getString("genericDescribePath").format(version, id)
+    def genericDescribeUrl(version: Int, id: String) = server + genericDescribePath(version, id)
+
+    def genericDescribeUpPath(version: Int, id: String) = dm.getString("genericDescribeUpPath").format(version, id)
+    def genericDescribeUpUrl(version: Int, id: String) = server + genericDescribeUpPath(version, id)
+
+    def genericDescribeDownPath(version: Int, id: String) = dm.getString("genericDescribeDownPath").format(version, id)
+    def genericDescribeDownUrl(version: Int, id: String) = server + genericDescribeDownPath(version, id)
+
+    def genericSearchPath(version: Int) = dm.getString("genericSearchPath").format(version)
+    def genericSearchUrl(version: Int) = server + genericSearchPath(version)
   }
 
   object BOSS {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericDescribeService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericDescribeService.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.vault.services.generic
 import javax.ws.rs.Path
 
 import com.wordnik.swagger.annotations._
-import org.broadinstitute.dsde.vault.common.directives.VersioningDirectives._
 import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
 import org.broadinstitute.dsde.vault.model.{GenericRelationship, GenericRelEnt, GenericEntity, GenericSysAttrs}
 import spray.http.MediaTypes._
@@ -13,26 +12,26 @@ import spray.routing.HttpService
 @Api(value="/entities", description="generic entity service", produces="application/json")
 trait GenericDescribeService extends HttpService {
   private final val ApiPrefix = "entities"
-  private final val ApiVersions = "v1"
-  private final val DefaultVersion = 1
+
+  private final val SwaggerApiVersions = "v1"
 
   // up and down are more specific matches of the same route, so they must be listed first
   val gdRoutes = findUpstreamRoute ~ findDownstreamRoute ~ describeRoute
 
   @ApiOperation(
-    value="get data for a particular entity",
-    nickname="fetchEntity",
-    httpMethod="GET",
-    response=classOf[GenericEntity])
+    value = "get data for a particular entity",
+    nickname = "fetchEntity",
+    httpMethod = "GET",
+    response = classOf[GenericEntity])
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name="version", required=true, dataType="string", paramType="path", value="API version", allowableValues=ApiVersions),
-    new ApiImplicitParam(name="id", required=true, dataType="string", paramType="path", value="vault ID")))
+    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = SwaggerApiVersions),
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "vault ID")))
   @ApiResponses(Array(
-    new ApiResponse(code=200, message="Successful"),
-    new ApiResponse(code=404, message="Not Found"),
-    new ApiResponse(code=500, message="Internal Error")))
+    new ApiResponse(code = 200, message = "Successful"),
+    new ApiResponse(code = 404, message = "Not Found"),
+    new ApiResponse(code = 500, message = "Internal Error")))
   def describeRoute = {
-    pathVersion(ApiPrefix,DefaultVersion,Segment) { (version, guid) =>
+    path(ApiPrefix / "v" ~ IntNumber / Segment) { (version, guid) =>
       get {
         respondWithMediaType(`application/json`) {
           complete {
@@ -51,20 +50,20 @@ trait GenericDescribeService extends HttpService {
 
   @Path("/{version}/{id}?up")
   @ApiOperation(
-    value="get entities upstream of a specified entity",
-    nickname="findUpstream",
-    httpMethod="GET",
-    response=classOf[GenericRelEnt],
-    responseContainer="List")
+    value = "get entities upstream of a specified entity",
+    nickname = "findUpstream",
+    httpMethod = "GET",
+    response = classOf[GenericRelEnt],
+    responseContainer = "List")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name="version", required=true, dataType="string", paramType="path", value="API version", allowableValues=ApiVersions),
-    new ApiImplicitParam(name="id", required=true, dataType="string", paramType="path", value="vault ID")))
+    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = SwaggerApiVersions),
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "vault ID")))
   @ApiResponses(Array(
-    new ApiResponse(code=200, message="Successful"),
-    new ApiResponse(code=404, message="Not Found"),
-    new ApiResponse(code=500, message="Internal Error")))
+    new ApiResponse(code = 200, message = "Successful"),
+    new ApiResponse(code = 404, message = "Not Found"),
+    new ApiResponse(code = 500, message = "Internal Error")))
   def findUpstreamRoute = {
-    pathVersion(ApiPrefix,DefaultVersion,Segment) { (version, guid) =>
+    path(ApiPrefix / "v" ~ IntNumber / Segment) { (version, guid) =>
       get {
         parameters('up) { up =>
           respondWithMediaType(`application/json`) {
@@ -88,20 +87,20 @@ trait GenericDescribeService extends HttpService {
 
   @Path("/{version}/{id}?down")
   @ApiOperation(
-    value="get entities downstream of a specified entity",
-    nickname="findDownstream",
-    httpMethod="GET",
-    response=classOf[GenericRelEnt],
-    responseContainer="List")
+    value = "get entities downstream of a specified entity",
+    nickname = "findDownstream",
+    httpMethod = "GET",
+    response = classOf[GenericRelEnt],
+    responseContainer = "List")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name="version", required=true, dataType="string", paramType="path", value="API version", allowableValues=ApiVersions),
-    new ApiImplicitParam(name="id", required=true, dataType="string", paramType="path", value="vault ID")))
+    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = SwaggerApiVersions),
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "vault ID")))
   @ApiResponses(Array(
-    new ApiResponse(code=200, message="Successful"),
-    new ApiResponse(code=404, message="Not Found"),
-    new ApiResponse(code=500, message="Internal Error")))
+    new ApiResponse(code = 200, message = "Successful"),
+    new ApiResponse(code = 404, message = "Not Found"),
+    new ApiResponse(code = 500, message = "Internal Error")))
   def findDownstreamRoute = {
-    pathVersion(ApiPrefix,DefaultVersion,Segment) { (version, guid) =>
+    path(ApiPrefix / "v" ~ IntNumber / Segment) { (version, guid) =>
       get {
         parameters('down) { down =>
           respondWithMediaType(`application/json`) {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericIngestService.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.vault.services.generic
 import com.wordnik.swagger.annotations._
 import org.broadinstitute.dsde.vault.services.VaultDirectives
 import org.broadinstitute.dsde.vault.{GenericDmClientService, BossClientService}
-import org.broadinstitute.dsde.vault.common.directives.VersioningDirectives._
 import org.broadinstitute.dsde.vault.model.{GenericEntity, GenericIngest}
 import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
 import spray.httpx.SprayJsonSupport._
@@ -12,8 +11,8 @@ import spray.routing.HttpService
 @Api(value="/entities", description="generic entity service", produces="application/json")
 trait GenericIngestService extends HttpService with VaultDirectives {
   private final val ApiPrefix = "entities"
-  private final val ApiVersions = "v1"
-  private final val DefaultVersion = 1
+
+  private final val SwaggerApiVersions = "v1"
 
   val giRoute = ingestRoute
 
@@ -25,14 +24,14 @@ trait GenericIngestService extends HttpService with VaultDirectives {
     responseContainer = "List",
     notes = "response is a list of the new entities")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = ApiVersions),
+    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = SwaggerApiVersions),
     new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.vault.model.GenericIngest", paramType = "body", value = "entities and relations to create")))
   @ApiResponses(Array(
     new ApiResponse(code = 200, message = "Successful"),
     new ApiResponse(code = 400, message = "Bad Request"),
     new ApiResponse(code = 500, message = "Internal Error")))
   def ingestRoute = {
-    pathVersion(ApiPrefix, DefaultVersion) { version =>
+    path(ApiPrefix / "v" ~ IntNumber) { version =>
       post {
         entity(as[GenericIngest]) { ingest =>
           respondWithJSON { requestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericIngestService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericIngestService.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.vault.services.generic
 
 import com.wordnik.swagger.annotations._
+import org.broadinstitute.dsde.vault.services.VaultDirectives
+import org.broadinstitute.dsde.vault.{GenericDmClientService, BossClientService}
 import org.broadinstitute.dsde.vault.common.directives.VersioningDirectives._
-import org.broadinstitute.dsde.vault.model.{GenericSysAttrs, GenericEntity, GenericIngest}
+import org.broadinstitute.dsde.vault.model.{GenericEntity, GenericIngest}
 import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
-import spray.json._
-import spray.http.MediaTypes._
 import spray.httpx.SprayJsonSupport._
 import spray.routing.HttpService
 
 @Api(value="/entities", description="generic entity service", produces="application/json")
-trait GenericIngestService extends HttpService {
+trait GenericIngestService extends HttpService with VaultDirectives {
   private final val ApiPrefix = "entities"
   private final val ApiVersions = "v1"
   private final val DefaultVersion = 1
@@ -35,20 +35,11 @@ trait GenericIngestService extends HttpService {
     pathVersion(ApiPrefix, DefaultVersion) { version =>
       post {
         entity(as[GenericIngest]) { ingest =>
-          respondWithMediaType(`application/json`) {
-            complete {
-              //STUB
-
-              // for entity <- ingest.entities
-              // use entity.blob to interact with BOSS, receive bossId and signedPutUrl
-              // remove entity.blob, add entity.sysAttrs.bossId
-              // register entity in DM, receive vault guid
-              // remove entity.sysAttrs.bossId, add entity.guid and entity.signedPutUrl
-
-              val sysAttrs = GenericSysAttrs(bossID = None, 12345, "stub user", None, None)
-              List(GenericEntity("entity 1 guid", Option("entity 1 signedPutUrl"), None, "stub", sysAttrs, None),
-                GenericEntity("entity 2 guid", Option("entity 2 signedPutUrl"), None, "stub", sysAttrs, None) ).toJson.prettyPrint
-            }
+          respondWithJSON { requestContext =>
+            val bossService = actorRefFactory.actorOf(BossClientService.props(requestContext))
+            val dmService = actorRefFactory.actorOf(GenericDmClientService.props(requestContext))
+            val ingestActor = actorRefFactory.actorOf(IngestServiceHandler.props(requestContext, version, bossService, dmService))
+            ingestActor ! IngestServiceHandler.IngestMessage(ingest)
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericSearchService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/generic/GenericSearchService.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.vault.services.generic
 
 import com.wordnik.swagger.annotations._
-import org.broadinstitute.dsde.vault.common.directives.VersioningDirectives._
 import org.broadinstitute.dsde.vault.model._
 import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
 import spray.http.MediaTypes._
@@ -13,9 +12,9 @@ import javax.ws.rs.Path
 @Api(value="/entities", description="generic entity service", produces="application/json")
 trait GenericSearchService extends HttpService {
   private final val ApiPrefix = "entities"
-  private final val ApiVersions = "v1"
-  private final val DefaultVersion = 1
   private final val ApiSuffix = "search"
+
+  private final val SwaggerApiVersions = "v1"
 
   val gsRoute = searchRoute
 
@@ -27,7 +26,7 @@ trait GenericSearchService extends HttpService {
     response = classOf[GenericEntity],
     responseContainer = "List")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = ApiVersions),
+    new ApiImplicitParam(name = "version", required = true, dataType = "string", paramType = "path", value = "API version", allowableValues = SwaggerApiVersions),
     new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.vault.model.GenericEntityQuery", paramType = "body", value = "entities to find")))
   @ApiResponses(Array(
     new ApiResponse(code = 200, message = "Successful"),
@@ -35,7 +34,7 @@ trait GenericSearchService extends HttpService {
     new ApiResponse(code = 404, message = "Not Found"),
     new ApiResponse(code = 500, message = "Internal Error")))
   def searchRoute = {
-    pathVersion(ApiPrefix, DefaultVersion, ApiSuffix) { version =>
+    path(ApiPrefix / "v" ~ IntNumber / ApiSuffix) { version =>
       post {
         entity(as[GenericEntityQuery]) { query =>
           respondWithMediaType(`application/json`) {

--- a/src/main/scala/org/broadinstitute/dsde/vault/services/generic/IngestServiceHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/services/generic/IngestServiceHandler.scala
@@ -1,0 +1,241 @@
+package org.broadinstitute.dsde.vault.services.generic
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.event.Logging
+import org.broadinstitute.dsde.vault.BossClientService
+import org.broadinstitute.dsde.vault.BossClientService.{BossObjectCreated, BossObjectResolved}
+import org.broadinstitute.dsde.vault.GenericDmClientService.{DMGenericDescribeResponse, DMGenericDescribe, DMGenericIngestResponse, DMGenericIngest}
+import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
+import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.ClientFailure
+import org.broadinstitute.dsde.vault.services.generic.IngestServiceHandler.IngestMessage
+import spray.routing.RequestContext
+import spray.json._
+import scala.collection.immutable.SortedMap
+
+object IngestServiceHandler {
+
+  case class IngestMessage(ingest: GenericIngest)
+
+  def props(requestContext: RequestContext, version: Int, bossService: ActorRef, dmService: ActorRef): Props =
+    Props(new IngestServiceHandler(requestContext, version, bossService, dmService))
+}
+
+case class IngestServiceHandler(requestContext: RequestContext, dmGenericIngestVersion: Int, bossService: ActorRef, dmService: ActorRef) extends Actor {
+
+  implicit val system = context.system
+  val log = Logging(system, getClass)
+
+  def registerInBoss(objSpec: DataObjectSpecification, index: Int): Unit = {
+    objSpec.ingestMethod match {
+      case "new" =>
+        val filePath = "nonsense_generic_vault_path"   // TODO: better solution for this
+        val noForceLocation = Some("false")
+        bossService ! BossClientService.BossCreateObject(BossDefaults.getCreationRequest(filePath, noForceLocation), index.toString)
+
+      case other =>
+        log.error("Ingest method %s not implemented".format(other))
+        requestContext.reject()
+        context.stop(self)
+    }
+  }
+
+  def bossRegistrationCheck(ingest: GenericIngest, entities: List[GenericEntityIngest], relations: List[GenericRelationshipIngest], needsRegistration: Set[Int]) = {
+    if (needsRegistration.isEmpty) {
+      dmService ! DMGenericIngest(ingest, dmGenericIngestVersion)
+      context become dmRegistrationState(List())
+    }
+    else
+      context become bossRegistrationState(entities, relations, needsRegistration)
+  }
+
+  def dmResolutionCheck(entities: SortedMap[Int, GenericEntity], needsDmResolution: Set[Int]): Unit = {
+    if (needsDmResolution.isEmpty) {
+      var bossEntityIndex: Int = 0
+      var needsBossResolution: Set[Int] = Set()
+
+      entities foreach { case (index, ent) =>
+        ent.sysAttrs.bossID foreach { id =>
+          bossService ! BossClientService.BossResolveObject(BossDefaults.getResolutionRequest("PUT"), id, index.toString)
+          needsBossResolution += index
+        }
+
+        bossEntityIndex += 1
+      }
+
+      bossResolutionCheck(entities, needsBossResolution)
+    }
+    else
+      context become dmResolutionState(entities, needsDmResolution)
+  }
+
+  def bossResolutionCheck(entities: SortedMap[Int, GenericEntity], needsResolution: Set[Int]) = {
+    if (needsResolution.isEmpty) {
+      requestContext.complete(entities.values.toList.toJson.prettyPrint)
+      context.stop(self)
+    }
+    else
+      context become bossResolutionState(entities, needsResolution)
+  }
+
+  // Generic Ingest State Machine
+  //
+  // INITIAL
+  //    only valid incoming message is IngestMessage
+  //    parse incoming entities for BOSS requirements.  If registration needed:
+  //      send BossCreateObject for those which need it
+  //      add to needsRegistration
+  //    if needsRegistration is not empty, transition to BOSS_REGISTRATION(newEntities, relations, newNeedsRegistration)
+  //    if empty, send DMGenericIngest and transition to DM_REGISTRATION
+  //
+  // BOSS_REGISTRATION(entities, relations, needsRegistration)
+  //    only valid incoming message is BossObjectCreated
+  //    update entities at the appropriate index with the bossID
+  //    remove the appropriate entity from needsRegistration
+  //    if needsRegistration is not empty, transition to BOSS_REGISTRATION(newEntities, relations, newNeedsRegistration)
+  //    if empty, send DMGenericIngest and transition to DM_REGISTRATION
+  //
+  // DM_REGISTRATION
+  //    only valid incoming message is DMGenericIngestResponse
+  //    send DMGenericDescribe for each guid
+  //    transition to DM_RESOLUTION((), needsResolution, ())
+  //
+  // DM_RESOLUTION(entities, needsDmResolution, needsBossResolution)
+  //    only valid incoming message is DMGenericDescribeResponse
+  //    add incoming entity to entities and remove from needsDmResolution
+  //    parse incoming entities for BOSS IDs.  If found:
+  //      remove BOSS ID
+  //      add to needsBossResolution
+  //    if needsDmResolution is not empty, transition to DM_RESOLUTION(newEntities, newNeedsDmResolution, needsBossResolution)
+  //    if empty, send BossResolveObject for all in needsBossResolution and transition to BOSS_RESOLUTION(entities, needsBossResolution)
+  //
+  // BOSS_RESOLUTION(entities, needsResolution)
+  //    only valid incoming message is BossObjectResolved
+  //    update entities at the appropriate index with the genericPutUrl
+  //    remove the appropriate entity from needsResolution
+  //    if newNeedsResolution is not empty, transition to BOSS_RESOLUTION(newEntities, newNeedsResolution)
+  //    if empty, complete client request with newEntities
+
+  // TODO: allow BOSS resolution in parallel with DM registration/resolution
+
+  def receive = initialState
+
+  def initialState: Actor.Receive = {
+    case IngestMessage(ingest) =>
+      log.debug("Received Generic Ingest message")
+
+      var entityIndex: Int = 0
+      var needsRegistration: Set[Int] = Set()
+
+      // double foreach here because it's Option[List[GenericEntityIngest]]
+      ingest.entities foreach { l => l foreach { ent =>
+        ent.dataObject foreach { objectSpec =>
+          needsRegistration += entityIndex
+          registerInBoss(objectSpec, entityIndex)
+        }
+
+        entityIndex += 1
+      }}
+
+      bossRegistrationCheck(ingest, ingest.entities getOrElse List(), ingest.relations getOrElse List(), needsRegistration)
+ 
+    case ClientFailure(message: String) =>
+      log.error("Client Failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+    case _ =>
+      log.error("Illegal State Exception: Generic Ingest INITIAL")
+      requestContext.reject()
+      context.stop(self)
+  }
+
+  def bossRegistrationState(entities: List[GenericEntityIngest], relations: List[GenericRelationshipIngest], needsRegistration: Set[Int]): Actor.Receive = {
+    case BossObjectCreated(bossObject: BossCreationObject, creationKey: String) =>
+      log.debug("Received BossObjectCreated message.  Current state: %s entities (%s need registration) and %s relations".format(entities.size, needsRegistration.size, relations.size))
+      val entityIndex = creationKey.toInt
+      val newNeedsRegistration = needsRegistration - entityIndex
+      val newEntities = entities.updated(entityIndex, entities(entityIndex).copy(bossID = bossObject.objectId))
+
+      bossRegistrationCheck(GenericIngest(Option(newEntities), Option(relations)), newEntities, relations, newNeedsRegistration)
+
+    case ClientFailure(message: String) =>
+      log.error("Client Failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+    case _ =>
+      log.error("Illegal State Exception: Generic Ingest BOSS REGISTRATION")
+      requestContext.reject()
+      context.stop(self)
+  }
+
+  def dmRegistrationState(entities: List[GenericEntity]): Actor.Receive = {
+    case DMGenericIngestResponse(guids: List[String]) =>
+      log.debug("Received DMGenericIngestResponse message.  Current state: %s entities".format(entities.size))
+      var entityIndex: Int = 0
+      var needsResolution: Set[Int] = Set()
+
+      guids foreach { id =>
+        needsResolution += entityIndex
+        dmService ! DMGenericDescribe(id, dmGenericIngestVersion, entityIndex)
+
+        entityIndex += 1
+      }
+
+      context become dmResolutionState(SortedMap(), needsResolution)
+
+    case ClientFailure(message: String) =>
+      log.error("Client Failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+    case _ =>
+      log.error("Illegal State Exception: Generic Ingest DM REGISTRATION")
+      requestContext.reject()
+      context.stop(self)
+  }
+
+  def dmResolutionState(entities: SortedMap[Int, GenericEntity], needsResolution: Set[Int]): Actor.Receive = {
+    case DMGenericDescribeResponse(entity: GenericEntity, entityIndex: Int) =>
+      log.debug("Received DMGenericDescribeResponse message.  Current state: %s entities (%s need resolution)".format(entities.size, needsResolution.size))
+      val newNeedsResolution = needsResolution - entityIndex
+      val newEntities = entities + (entityIndex -> entity)
+      
+      dmResolutionCheck(newEntities, newNeedsResolution)
+
+    case ClientFailure(message: String) =>
+      log.error("Client Failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+    case _ =>
+      log.error("Illegal State Exception: Generic Ingest DM REGISTRATION")
+      requestContext.reject()
+      context.stop(self)
+  }
+
+  def bossResolutionState(entities: SortedMap[Int, GenericEntity], needsResolution: Set[Int]): Actor.Receive = {
+    case BossObjectResolved(bossObject: BossResolutionResponse, creationKey: String) =>
+      log.debug("Received BossObjectResolved message.  Current state: %s entities (%s need resolution)".format(entities.size, needsResolution.size))
+      val entityIndex = creationKey.toInt
+      val newNeedsResolution = needsResolution - entityIndex
+
+      // set signedPutUrl and clear sysAttrs.bossID
+      val oldEntity = entities(entityIndex)
+      val newEntity = oldEntity.copy(signedPutUrl = Option(bossObject.objectUrl), sysAttrs = oldEntity.sysAttrs.copy(bossID = None))
+      val newEntities = entities + (entityIndex -> newEntity)
+
+      bossResolutionCheck(newEntities, newNeedsResolution)
+
+    case ClientFailure(message: String) =>
+      log.error("Client Failure: " + message)
+      requestContext.reject()
+      context.stop(self)
+
+    case _ =>
+      log.error("Illegal State Exception: Generic Ingest BOSS RESOLUTION")
+      requestContext.reject()
+      context.stop(self)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/vault/services/GenericServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/services/GenericServiceSpec.scala
@@ -1,0 +1,76 @@
+package org.broadinstitute.dsde.vault.services
+
+import org.broadinstitute.dsde.vault.{VaultConfig, VaultFreeSpec}
+import org.broadinstitute.dsde.vault.model._
+import org.broadinstitute.dsde.vault.services.generic.GenericIngestService
+
+import org.broadinstitute.dsde.vault.model.GenericJsonProtocol._
+import spray.httpx.SprayJsonSupport._
+
+class GenericServiceSpec extends VaultFreeSpec with GenericIngestService {
+
+  def actorRefFactory = system
+
+  "GenericService" - {
+
+    val routes = giRoute
+
+    val versions = Table(
+      "version",
+      1
+    )
+
+    forAll(versions) { (version: Int) =>
+
+      val ingestPath = VaultConfig.Vault.genericIngestPath(version)
+
+      s"when accessing the $ingestPath path" - {
+        val aValue = "arbitrary_value"
+
+        val uBAMAttrs = Map("ownerId" -> "me", "queryAttr" -> aValue)
+        val bamAttrs = Map("bamFile" -> "test.bam")
+        val baiAttrs = Map("baiFile" -> "test.bai")
+        val bamRelAttrs = Map("name" -> "bam")
+        val baiRelAttrs = Map("name" -> "bai")
+
+        val objSpec = DataObjectSpecification(ingestMethod = "new", source = None)
+
+        val ingest = GenericIngest(
+            Some(List(GenericEntityIngest("unmappedBAM", None, None, uBAMAttrs),
+                      GenericEntityIngest("bamFile", None, Some(objSpec), bamAttrs),
+                      GenericEntityIngest("baiFile", None, Some(objSpec), baiAttrs))),
+            Some(List(GenericRelationshipIngest("fileType","$0","$1",bamRelAttrs),
+                      GenericRelationshipIngest("fileType","$0","$2",baiRelAttrs))))
+
+        "POST should store a new uBAM generically" in {
+          Post(ingestPath, ingest) ~> addOpenAmCookie ~> sealRoute(routes) ~> check {
+            val entities = responseAs[List[GenericEntity]]
+
+            entities should have length 3
+
+            entities(0).entityType should be("unmappedBAM")
+            entities(0).attrs.nonEmpty should be(true)
+            entities(0).attrs.get should be(uBAMAttrs)
+
+            entities(1).entityType should be("bamFile")
+            entities(1).attrs.nonEmpty should be(true)
+            entities(1).attrs.get should be(bamAttrs)
+
+            entities(2).entityType should be("baiFile")
+            entities(2).attrs.nonEmpty should be(true)
+            entities(2).attrs.get should be(baiAttrs)
+
+            entities.tail foreach { ent =>
+              ent.guid should be a UUID
+              ent.signedPutUrl.nonEmpty should be(true)
+              ent.signedPutUrl.get should be a URL
+              ent.signedGetUrl.isEmpty should be(true)
+              ent.sysAttrs.bossID.isEmpty should be(true)
+            }
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Ingest for the generic API, a portion of DSDEV-1994

The `GenericDmClientService` is intended to eventually replace the original `DmClientService`.  We may wish to rename`GenericDmClientService` to `DmClientService` at that time.
